### PR TITLE
Auto Fast JNI Detection for x86 & x86_64

### DIFF
--- a/build/Android.common_path.mk
+++ b/build/Android.common_path.mk
@@ -125,6 +125,11 @@ ifneq ($(ART_BUILD_TARGET_DEBUG),false)
 ART_TARGET_EXECUTABLES += $(foreach name,$(ART_CORE_DEBUGGABLE_EXECUTABLES),$(name)d-target)
 endif
 
+CAPSTONE_EXT_LIBRARY := $(strip $(wildcard $$(ANDROID_BUILD_TOP)/external/capstone/Android.bp))
+ifneq ($$(CAPSTONE_EXT_LIBRARY),)
+  ART_CAPSTONE_INCLUDES := true
+endif
+
 ART_HOST_EXECUTABLES :=
 ifneq ($(ART_BUILD_HOST_NDEBUG),false)
 ART_HOST_EXECUTABLES += $(foreach name,$(ART_CORE_EXECUTABLES) $(ART_CORE_DEBUGGABLE_EXECUTABLES),$(name)-host)

--- a/build/art.go
+++ b/build/art.go
@@ -249,6 +249,22 @@ func prefer32Bit(ctx android.LoadHookContext) {
 	ctx.AppendProperties(p)
 }
 
+func capstoneLinker(ctx android.LoadHookContext) {
+       type props struct {
+		Cflags   []string
+		Asflags  []string
+       }
+       p := &props{}
+       p.Cflags, p.Asflags = globalFlags(ctx)
+
+       if !envFalse(ctx, "ART_CAPSTONE_INCLUDES") && ctx.AConfig().AutoFastJni() {
+	       fmt.Println("capstonelink:", true)
+	       p.Cflags = append(p.Cflags, "-DCAPSTONE=1")
+	       p.Asflags = append(p.Asflags, "-DCAPSTONE=1")
+	       ctx.AppendProperties(p)
+       }
+}
+
 func testMap(config android.Config) map[string][]string {
 	return config.Once("artTests", func() interface{} {
 		return make(map[string][]string)
@@ -282,6 +298,7 @@ func init() {
 	android.RegisterModuleType("art_cc_binary", artBinary)
 	android.RegisterModuleType("art_cc_test", artTest)
 	android.RegisterModuleType("art_cc_test_library", artTestLibrary)
+	android.RegisterModuleType("art_capstone_dependancies", artCapstoneDependancies)
 	android.RegisterModuleType("art_cc_defaults", artDefaultsFactory)
 	android.RegisterModuleType("art_global_defaults", artGlobalDefaultsFactory)
 	android.RegisterModuleType("art_debug_defaults", artDebugDefaultsFactory)
@@ -306,6 +323,12 @@ func artDefaultsFactory() android.Module {
 	module := cc.DefaultsFactory(c)
 	android.AddLoadHook(module, func(ctx android.LoadHookContext) { codegen(ctx, c, true) })
 
+	return module
+}
+
+func  artCapstoneDependancies() android.Module {
+	module := artDefaultsFactory()
+        android.AddLoadHook(module, capstoneLinker)
 	return module
 }
 

--- a/libartbase/base/logging.h
+++ b/libartbase/base/logging.h
@@ -58,6 +58,7 @@ struct LogVerbosity {
   bool systrace_lock_logging;  // Enabled with "-verbose:sys-locks".
   bool agents;
   bool dex;  // Some dex access output etc.
+  bool autofast_jni;
 };
 
 // Global log verbosity setting, initialized by InitLogging.

--- a/runtime/Android.bp
+++ b/runtime/Android.bp
@@ -25,7 +25,7 @@ JIT_DEBUG_REGISTER_CODE_LDFLAGS = [
 
 cc_defaults {
     name: "libart_defaults",
-    defaults: ["art_defaults"],
+    defaults: ["libcapstone-defaults","art_defaults"],
     host_supported: true,
     srcs: [
         "aot_class_linker.cc",
@@ -526,6 +526,28 @@ art_cc_library {
         "external/icu/icu4c/source/common",
     ],
 }
+
+art_capstone_dependancies {
+    name: "libcapstone-defaults",
+    host_supported: true,
+    clang: true,
+
+    product_variables: {
+       autoFastJni: {
+             srcs: [
+                "binary_analyzer/binary_analyzer_x86.cc",
+                "binary_analyzer/disassembler.cc",
+             ],
+             include_dirs: [
+                 "external/capstone/include",
+                 "external/capstone",
+             ],
+             shared_libs: ["libcapstone"],
+        },
+    },
+
+}
+
 
 art_cc_test {
     name: "art_runtime_tests",

--- a/runtime/binary_analyzer/binary_analyzer.h
+++ b/runtime/binary_analyzer/binary_analyzer.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ART_RUNTIME_BINARY_ANALYZER_BINARY_ANALYZER_H_
+#define ART_RUNTIME_BINARY_ANALYZER_BINARY_ANALYZER_H_
+
+#include <cstdint>
+
+#include "binary_analyzer_x86.h"
+#include "dex/dex_file.h"
+#include "runtime.h"
+//#include "utils.h"
+namespace capstone{
+// Make sure capstone does not pollute the global namespace.
+extern "C" {
+#include <capstone.h>
+}
+}
+using namespace capstone;
+
+namespace art {
+
+static bool IsFastJNI(uint32_t method_idx, const DexFile& dex_file, const void* fn_ptr) {
+  bool is_fast = false;
+  InstructionSet instruction_set = Runtime::Current()->GetInstructionSet();
+  switch (instruction_set) {
+    case InstructionSet::kX86:
+    case InstructionSet::kX86_64: {
+      x86::AnalysisResult result = x86::AnalyzeMethod(method_idx, dex_file, fn_ptr);
+      if (result == x86::AnalysisResult::kFast) {
+        is_fast = true;
+        VLOG(autofast_jni) <<  dex_file.PrettyMethod(method_idx) << " is a fast JNI Method";
+      } else {
+        VLOG(autofast_jni) <<  dex_file.PrettyMethod(method_idx) << " is not a fast JNI Method: "
+                           << x86::AnalysisResultToStr(result);
+      }
+      break;
+    }
+    case InstructionSet::kArm:
+    case InstructionSet::kArm64:
+    case InstructionSet::kMips:
+    case InstructionSet::kMips64:
+      break;
+    default:
+      LOG(ERROR) << "Unsupported ISA!";
+      break;
+  }
+  return is_fast;
+}
+
+}  // namespace art
+
+#endif  // ART_RUNTIME_BINARY_ANALYZER_BINARY_ANALYZER_H_

--- a/runtime/binary_analyzer/binary_analyzer_x86.cc
+++ b/runtime/binary_analyzer/binary_analyzer_x86.cc
@@ -1,0 +1,759 @@
+/*
+ * Copyright (C) 2016 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "binary_analyzer_x86.h"
+
+#include <inttypes.h>
+#include <iostream>
+#include <ostream>
+#include <sstream>
+#include "android-base/stringprintf.h"
+#include "base/logging.h"
+#include "thread.h"
+
+namespace art {
+namespace x86 {
+
+using android::base::StringPrintf;
+
+// Budgetary constraints for classifying a native method as fast.
+static constexpr size_t kCallDepthLimit = 3;
+static constexpr size_t kBasicBlockLimit = 20;
+static constexpr size_t kInstructionLimit = 100;
+
+enum ControlTransferType {
+  kNone,                 // Instructions with no control flow transfer.
+  kConditionalBranch,    // Conditional branch.
+  kUnconditionalBranch,  // Unconditional branch.
+  kInterrupt,            // Software Interrupt.
+  kCall,                 // Direct call.
+  kUnknown,              // Unsupported instruction.
+  kIndirectCall,         // Indirect call.
+  kIndirectJump,         // Indirect jump.
+  kReturn,               // Return instruction.
+  kLock,                 // Lock prefix.
+  kCycle,                // Cycling prefix/instruction.
+};
+
+/**
+ * @brief Analyze how instruction affects control flow (see ControlTransferType)
+ * @param instr - The instruction pointer.
+ * @param curr_bb - Pointer to the Current Basic Block.
+ * @param is_bb_end - Does the instruction mark the end of Basic Block.
+ * @param target - Adress for direct jump/call.
+ * @param disassembler - Disassembler to be used for instruction decoding.
+ * @return Size of analyzed instruction in bytes. -1 in case of error.
+ */
+ptrdiff_t AnalyzeInstruction(const uint8_t* instr,
+                             MachineBlock* curr_bb,
+                             int32_t* is_bb_end,
+                             const uint8_t** target,
+                             Disassembler* disassembler) {
+  *is_bb_end = kNone;
+  if (!disassembler->IsDisassemblerValid()) {
+    return -1;
+  }
+  disassembler->Seek(instr);
+  const cs_insn* insn = disassembler->Next();
+  if (insn == nullptr) {
+    return -1;
+  }
+  *target = instr + insn->size;
+  const cs_x86& insn_x86 = insn->detail->x86;
+
+  switch(insn_x86.prefix[0]) {
+  case X86_PREFIX_REP:
+  case X86_PREFIX_REPNE:
+    *is_bb_end = kCycle;
+    break;
+  case X86_PREFIX_LOCK:
+    *is_bb_end = kLock;
+    break;
+  }
+
+  switch(insn->id) {
+  case X86_INS_LOOP:
+  case X86_INS_LOOPE:
+  case X86_INS_LOOPNE:
+    *is_bb_end = kCycle;
+    break;
+  case X86_INS_INVALID:
+    *is_bb_end = kUnknown;
+    break;
+  case X86_INS_INT:
+  case X86_INS_INT1:
+  case X86_INS_INT3:
+    *is_bb_end = kInterrupt;
+    break;
+  case X86_INS_JMP:
+    DCHECK_GE(insn_x86.op_count, 1);
+    if (insn_x86.operands[0].type != X86_OP_IMM) {
+      *is_bb_end = kIndirectJump;
+    } else {
+      *is_bb_end = kUnconditionalBranch;
+      *target = reinterpret_cast<uint8_t*>(insn_x86.operands[0].imm);
+    }
+    break;
+  case X86_INS_JA:
+  case X86_INS_JAE:
+  case X86_INS_JB:
+  case X86_INS_JBE:
+  case X86_INS_JCXZ:
+  case X86_INS_JE:
+  case X86_INS_JECXZ:
+  case X86_INS_JG:
+  case X86_INS_JGE:
+  case X86_INS_JL:
+  case X86_INS_JLE:
+  case X86_INS_JNE:
+  case X86_INS_JNO:
+  case X86_INS_JNP:
+  case X86_INS_JNS:
+  case X86_INS_JO:
+  case X86_INS_JP:
+  case X86_INS_JRCXZ:
+  case X86_INS_JS:
+    DCHECK_GE(insn_x86.op_count, 1);
+    if (insn_x86.operands[0].type != X86_OP_IMM) {
+      *is_bb_end = kIndirectJump;
+    } else {
+      *is_bb_end = kConditionalBranch;
+      *target = reinterpret_cast<uint8_t*>(insn_x86.operands[0].imm);
+    }
+    break;
+  case X86_INS_RET:
+    *is_bb_end = kReturn;
+    break;
+  case X86_INS_CALL:
+    DCHECK_GE(insn_x86.op_count, 1);
+    if (insn_x86.operands[0].type != X86_OP_IMM) {
+      *is_bb_end = kIndirectCall;
+    } else {
+      *is_bb_end = kCall;
+      *target = reinterpret_cast<uint8_t*>(insn_x86.operands[0].imm);
+    }
+    break;
+  }
+  MachineInstruction* ir = new MachineInstruction(std::string(insn->mnemonic) + " " + insn->op_str,
+                                                  static_cast<uint8_t>(insn->size),
+                                                  reinterpret_cast<const uint8_t*>(instr));
+  MachineInstruction* prev_ir = curr_bb->GetLastInstruction();
+  ir->SetPrevInstruction(prev_ir);
+  if (prev_ir != nullptr) {
+    prev_ir->SetNextInstruction(ir);
+  }
+  curr_bb->AddInstruction(ir);
+  return insn->size;
+}
+
+MachineBlock* CFGraph::GetCorrectBB(MachineBlock* bblock) {
+  if (bblock->IsDummy()) {
+    if (!bblock->GetPredBBlockList().empty()) {
+      return bblock->GetPredBBlockList().front();
+    } else {
+      return nullptr;
+    }
+  } else {
+    return bblock;
+  }
+}
+
+bool CFGraph::IsVisited(const uint8_t* addr,
+                        MachineBlock* prev_bblock,
+                        MachineBlock* succ_bblock,
+                        std::vector<BackLogDs*>* backlog,
+                        const bool is_function_start) {
+  for (const auto current_bb : visited_bblock_list_) {
+    if (!current_bb->IsDummy()) {
+      const uint8_t* start = current_bb->GetStartAddr();
+      const uint8_t* end = current_bb->GetEndAddr();
+      // Recognize it as a cycle only if a back-branch found and it was a jmp, not call.
+      if (addr <= prev_bblock->GetEndAddr() && !is_function_start) {
+        this->SetHasCycles();
+      }
+
+      // In case we are branching to the beginning of an existing Basic Block,
+      // it is already visited.
+      if (addr == start) {
+        MachineBlock* bb_existing = current_bb;
+        if (prev_bblock->IsDummy()) {
+          prev_bblock->AddSuccBBlock(bb_existing);
+          bb_existing->AddPredBBlock(prev_bblock);
+          succ_bblock->AddPredBBlock(bb_existing);
+          bb_existing->AddSuccBBlock(succ_bblock);
+        } else {
+          prev_bblock->AddSuccBBlock(bb_existing);
+          bb_existing->AddPredBBlock(prev_bblock);
+        }
+        return true;
+      }
+
+      // In case we are branching to some address in the middle of an existing Basic Block,
+      // then that Basic Block needs to be split.
+      if ((addr > start) && (addr < end)) {
+        MachineBlock* bb_to_be_split = current_bb;
+
+        const uint8_t* prev_instr = nullptr;
+        const uint8_t* curr_instr = start;
+
+        // Scan the bblock that is being split to identify the end instruction.
+        const auto& instructions = bb_to_be_split->GetInstructions();
+
+        for (auto it_instr : instructions) {
+          prev_instr = curr_instr;
+          curr_instr = reinterpret_cast<const uint8_t*>(curr_instr + it_instr->GetLength());
+
+          // The previous instruction is the last instruction of the Basic Block being split.
+          if (curr_instr == addr) {
+            // Change the last instruction.
+            bb_to_be_split->SetEndAddr(prev_instr);
+            MachineBlock* new_bb = CreateBBlock(nullptr, nullptr);
+            const auto& succ_list = bb_to_be_split->GetSuccBBlockList();
+            bb_to_be_split->ClearSuccBBlockList();
+            bb_to_be_split->AddSuccBBlock(new_bb);
+            new_bb->AddPredBBlock(bb_to_be_split);
+            new_bb->CopySuccBBlockList(succ_list);
+            if (prev_bblock->IsDummy()) {
+              prev_bblock->AddSuccBBlock(new_bb);
+              new_bb->AddPredBBlock(prev_bblock);
+              succ_bblock->AddPredBBlock(new_bb);
+              new_bb->AddSuccBBlock(succ_bblock);
+            } else {
+              prev_bblock->AddSuccBBlock(new_bb);
+              new_bb->AddPredBBlock(prev_bblock);
+            }
+            AddTuple(new_bb, reinterpret_cast<const uint8_t*>(addr), end);
+            new_bb->CopyInstruction(bb_to_be_split, addr);
+            ChangePredForBacklog(bb_to_be_split, new_bb, backlog);
+            ChangePredecessors(succ_list, bb_to_be_split, new_bb);
+            if (prev_bblock == bb_to_be_split) {
+              new_bb->AddPredBBlock(new_bb);
+              new_bb->AddSuccBBlock(new_bb);
+            }
+            return true;
+          } else if (curr_instr > addr) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+  // Else, we have not visited this earlier.
+  return false;
+}
+
+void CFGraph::ChangePredecessors(const std::vector<MachineBlock*>& bblock_list,
+                                 MachineBlock* bblock_to_be_deleted,
+                                 MachineBlock* bblock_to_be_added) {
+  for (const auto it : bblock_list) {
+    it->DeletePredBBlock(bblock_to_be_deleted);
+    it->AddPredBBlock(bblock_to_be_added);
+  }
+}
+
+void CFGraph::ChangePredForBacklog(MachineBlock* old_pred,
+                                   MachineBlock* new_pred,
+                                   std::vector<BackLogDs*>* backlog) {
+  for (const auto bb : *backlog) {
+    if (bb->pred_bb->GetId() == old_pred->GetId()) {
+      bb->pred_bb = new_pred;
+      return;
+    }
+  }
+}
+
+void MachineBlock::CopyInstruction(MachineBlock* from_bblock, const uint8_t* start) {
+  const uint8_t* ptr = from_bblock->GetStartAddr();
+  std::list<MachineInstruction*>::iterator it_bb = from_bblock->instrs_.begin();
+  while (it_bb != from_bblock->instrs_.end()) {
+    if (ptr >= start) {
+      AddInstruction((*it_bb));
+      ptr += (*it_bb)->GetLength();
+      from_bblock->DeleteInstruction(it_bb++);
+    } else {
+      ptr += (*it_bb)->GetLength();
+      it_bb++;
+    }
+  }
+}
+
+void MachineBlock::DeleteInstruction(std::list<MachineInstruction*>::iterator it) {
+  instrs_.erase(it);
+  --num_of_instrs_;
+}
+
+bool CFGraph::IsVisitedForBacklog(BackLogDs* entry, std::vector<BackLogDs*>* backlog) {
+  if (entry != nullptr) {
+    MachineBlock* prev_bb = entry->pred_bb;
+    const uint8_t* addr = entry->ptr;
+    const bool is_function_start = entry->is_function_start;
+
+    if (prev_bb != nullptr) {
+      return IsVisited(addr, prev_bb, entry->succ_bb, backlog, is_function_start);
+    }
+  }
+  return false;
+}
+
+MachineBlock* GetTailBB(MachineBlock* bblock) {
+  MachineBlock* first_succ_bb = bblock->GetSuccBBlockList().front();
+  if (first_succ_bb == nullptr) {
+    return bblock;
+  } else {
+    return first_succ_bb;
+  }
+}
+
+/**
+ * @brief The Helper function to build CFG for the given method.
+ * @param cfg - The CFG.
+ * @param ptr - Instruction Pointer.
+ * @param curr_bb - Current Basic Block.
+ * @param backlog - Backlog array.
+ * @param depth - Call depth/levels of call nesting.
+ * @param dummy_end - Dummy basic block.
+ * @param disasm - Disassembler to be used for instructions decoding.
+ */
+void CFGHelper(CFGraph* cfg,
+               const uint8_t* instr_ptr,
+               MachineBlock* curr_bblock,
+               std::vector<BackLogDs*>* backlog,
+               uint32_t depth,
+               MachineBlock* dummy_end,
+               Disassembler* disasm,
+               CallGraph* call_graph) {
+  ptrdiff_t len = 0;
+  int32_t is_bb_end = kNone;
+  const uint8_t* target = nullptr;
+  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(instr_ptr);
+  const uint8_t* start_ptr = reinterpret_cast<const uint8_t*>(ptr);
+  while ((len = AnalyzeInstruction(ptr, curr_bblock, &is_bb_end, &target, disasm)) > 0) {
+
+    switch (is_bb_end) {
+    case kUnconditionalBranch: {
+      // Push the jmp target to backlog.
+      BackLogDs* uncond_jmp = new BackLogDs();
+      uncond_jmp->function_start = curr_bblock->GetFunctionStartAddr();
+      uncond_jmp->pred_bb = curr_bblock;
+      if (depth > 0) {
+        uncond_jmp->succ_bb = dummy_end;
+      } else {
+        uncond_jmp->succ_bb = nullptr;
+      }
+      uncond_jmp->ptr = target;
+      uncond_jmp->is_function_start = false;
+      uncond_jmp->call_depth = 0;
+      backlog->push_back(uncond_jmp);
+      // Add the current BB to CFG.
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kConditionalBranch: {
+      // Push the conditional (if) jmp target to backlog.
+      BackLogDs* cond_if_jmp = new BackLogDs();
+      cond_if_jmp->pred_bb = curr_bblock;
+      cond_if_jmp->function_start = curr_bblock->GetFunctionStartAddr();
+      if (depth > 0) {
+        cond_if_jmp->succ_bb = dummy_end;
+      } else {
+        cond_if_jmp->succ_bb = nullptr;
+      }
+      cond_if_jmp->ptr = target;
+      cond_if_jmp->call_depth = 0;
+      cond_if_jmp->is_function_start = false;
+      backlog->push_back(cond_if_jmp);
+      // Push the else (subsequent instruction) to the backlog.
+      BackLogDs* cond_else_jmp = new BackLogDs();
+      cond_else_jmp->is_function_start = false;
+      cond_else_jmp->pred_bb = curr_bblock;
+      cond_else_jmp->function_start = curr_bblock->GetFunctionStartAddr();
+      if (depth > 0) {
+        cond_else_jmp->succ_bb = dummy_end;
+      } else {
+        cond_else_jmp->succ_bb = nullptr;
+      }
+      cond_else_jmp->ptr = reinterpret_cast<const uint8_t*>(ptr + len);
+      cond_else_jmp->call_depth = 0;
+      backlog->push_back(cond_else_jmp);
+      // Add the current Basic Block to the CFG.
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kCall: {
+      // Add the current Basic Block to the CFG.
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      MachineBlock* start_bb = cfg->CreateBBlock(curr_bblock, curr_bblock->GetFunctionStartAddr());
+      MachineBlock* end_bb = cfg->CreateBBlock(nullptr, curr_bblock->GetFunctionStartAddr());
+      start_bb->SetDummy();
+      end_bb->SetDummy();
+      BackLogDs* call_entry = new BackLogDs();
+      call_entry->pred_bb = start_bb;
+      call_entry->ptr = target;
+      call_entry->function_start = target;
+      call_entry->succ_bb = end_bb;
+      call_entry->is_function_start = true;
+      call_entry->call_depth = depth + 1;
+      if (call_entry->call_depth > cfg->GetCallDepth()) {
+        cfg->SetCallDepth(call_entry->call_depth);
+      }
+      backlog->push_back(call_entry);
+      MachineBlock* bb_after_call = cfg->CreateBBlock(end_bb, curr_bblock->GetFunctionStartAddr());
+      curr_bblock = bb_after_call;
+      is_bb_end = kNone;
+      start_ptr = ptr + len;
+      cfg->AddTuple(start_bb, nullptr, nullptr);
+      cfg->AddTuple(end_bb, nullptr, nullptr);
+
+      call_graph->AddCall(curr_bblock->GetFunctionStartAddr(), target);
+      break;
+    }
+    case kReturn: {
+      if (dummy_end != nullptr) {
+        dummy_end->AddPredBBlock(curr_bblock);
+        curr_bblock->AddSuccBBlock(dummy_end);
+      }
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kInterrupt: {
+      cfg->SetHasInterrupts();
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kIndirectCall: {
+      cfg->SetHasIndirectCalls();
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kIndirectJump: {
+      cfg->SetHasIndirectJumps();
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kUnknown: {
+      cfg->SetHasUnknownInstructions();
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kLock: {
+      cfg->SetHasLocks();
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    case kCycle: {
+      cfg->SetHasCycles();
+      cfg->AddTuple(curr_bblock, start_ptr, reinterpret_cast<const uint8_t*>(ptr));
+      break;
+    }
+    }
+
+    ptr += len;
+    if (is_bb_end != kNone && is_bb_end != kCall) {
+      break;
+    }
+  }
+}
+
+/**
+ * @brief Constructs the CFG for the method by binary analysis.
+ * @param ptr - the method function pointer.
+ * @param method_name - Pretty Name of method.
+ * @return the CFG for the analyzed method.
+ */
+AnalysisResult AnalyzeCFG(const uint8_t* ptr, const std::string& method_name) {
+  CFGraph cfg(method_name);
+
+  auto call_graph = CallGraph::CreateNew();
+  Disassembler disassembler(Runtime::Current()->GetInstructionSet());
+  MachineBlock* predecessor_bb = nullptr;
+  MachineBlock* start_bb = cfg.CreateBBlock(predecessor_bb, nullptr);
+  MachineBlock* curr_bb = start_bb;
+  cfg.AddStartBBlock(start_bb);
+  MachineBlock* dummy_end = nullptr;
+  uint32_t depth = 0;
+  std::vector<BackLogDs*> backlog;
+  CFGHelper(&cfg, ptr, curr_bb, &backlog, depth, dummy_end, &disassembler, call_graph.get());
+
+  if (!cfg.IsStillFast()) {
+    for (auto& e : backlog) {
+        delete e;
+      }
+    return cfg.GetAnalysisState();
+  }
+
+  do {
+    BackLogDs* entry = nullptr;
+    if (!backlog.empty()) {
+      entry = backlog.back();
+      backlog.pop_back();
+      if (!cfg.IsVisitedForBacklog(entry, &backlog)) {
+        ptr = entry->ptr;
+        predecessor_bb  = entry->pred_bb;
+        curr_bb = cfg.CreateBBlock(predecessor_bb, entry->function_start);
+        dummy_end = entry->succ_bb;
+        depth = entry->call_depth;
+        CFGHelper(&cfg, ptr, curr_bb, &backlog, depth, dummy_end, &disassembler, call_graph.get());
+      }
+    }
+    delete entry;
+    if (!cfg.IsStillFast()) {
+      for (auto& e : backlog) {
+        delete e;
+      }
+      return cfg.GetAnalysisState();
+    }
+  } while ((!backlog.empty()));
+  if (CallGraph::HasCycles(std::move(call_graph))) {
+    return AnalysisResult::kHasCycles;
+  }
+
+  return cfg.GetAnalysisState();
+}
+
+bool CFGraph::IsStillFast() const {
+  return state_ == AnalysisResult::kFast;
+}
+
+void MachineInstruction::Print(std::ostream& os, bool is_dot) {
+  os << Print(is_dot).str();
+}
+
+void ReplaceString(std::string& subject,
+                   const std::string& search,
+                   const std::string& replace) {
+  size_t pos = 0;
+  while ((pos = subject.find(search, pos)) != std::string::npos) {
+    subject.replace(pos, search.length(), replace);
+    pos += replace.length();
+  }
+}
+
+std::ostringstream MachineInstruction::Print(bool is_dot) {
+  std::ostringstream os;
+  if (is_dot) {
+    ReplaceString(instr_, "0x", "");
+    os << instr_ << "\\l";
+  } else {
+    os << "\t\t" << instr_ << std::endl;
+  }
+  return os;
+}
+
+void MachineBlock::Print(std::ostream& os, bool is_dot) {
+  os << Print(is_dot).str();
+}
+
+std::ostringstream MachineBlock::Print(bool is_dot) {
+  std::ostringstream os;
+  if (is_dot) {
+    std::string label = StringPrintf("BB#%d\\n", id_);
+    if (!is_dummy_) {
+      std::ostringstream o_instr;
+      for (auto it : instrs_) {
+        it->Print(o_instr, true);
+      }
+      label = label + o_instr.str();
+    } else {
+      label = label + " (Dummy)";
+    }
+    os << StringPrintf("\nB_%d [shape=rectangle, label=\"%s\"];", id_, label.c_str());
+    for (MachineBlock* bb : succ_bblock_) {
+      os << StringPrintf("\nB_%d -> B_%d;", id_, bb->GetId());
+    }
+  } else {
+    os << "   Basic Block Id : " << id_
+       << "\n Call entry: 0x" << std::hex << size_t(function_start_addr_)
+       << "\n BB -No. of instructions " << GetInstrCnt()
+        << "\n    List of predecessor BBs : ";
+    for (auto it : pred_bblock_) {
+      os << it->GetId() << "   ";
+    }
+    os << "\n    List of successor BBs : ";
+    for (auto it : succ_bblock_) {
+      os << it->GetId() << "   ";
+    }
+    if (!is_dummy_) {
+      os << "\n   Instructions begin at : " << StringPrintf("%p", start_addr_) << "\n";
+      for (auto it : instrs_) {
+        it->Print(os, false);
+      }
+      os << "   Instructions end at : " << StringPrintf("%p", end_addr_) << "\n";
+    } else {
+      os << "\n Dummy BB \n";
+    }
+  }
+  return os;
+}
+
+void CFGraph::Print(std::ostringstream& os, bool is_dot) const {
+  if (is_dot) {
+    std::string method_name = GetMethodName();
+    ReplaceString(method_name, ".", "_");
+    ReplaceString(method_name, " ", "_");
+    ReplaceString(method_name, ",", "_");
+    ReplaceString(method_name, ")", "_");
+    ReplaceString(method_name, "(", "_");
+    os << "\ndigraph G_" << method_name <<" {";
+  } else {
+    os << "--- CFG begins ---\nCFG -No. of instructions " << GetInstructionCnt();
+  }
+  for (auto bb : visited_bblock_list_) {
+    bb->Print(os, is_dot);
+  }
+  if (is_dot) {
+    os << std::endl << "}";
+  } else {
+    os << "--- CFG ends ---\n";
+  }
+}
+
+MachineBlock::~MachineBlock() {
+  for (auto it : instrs_) {
+    delete it;
+  }
+}
+
+AnalysisResult AnalyzeMethod(uint32_t method_idx, const DexFile& dex_file, const void* fn_ptr) {
+  return AnalyzeCFG((unsigned char*) fn_ptr,dex_file.PrettyMethod(method_idx));
+}
+
+void MachineBlock::AddPredBBlock(MachineBlock* bblock) {
+  auto it = std::find(pred_bblock_.begin(), pred_bblock_.end(), bblock);
+  if (it == pred_bblock_.end()) {
+    pred_bblock_.push_back(bblock);
+  }
+  if (function_start_addr_ == nullptr && bblock != nullptr) {
+    function_start_addr_ = bblock->GetFunctionStartAddr();
+  }
+}
+
+void MachineBlock::AddSuccBBlock(MachineBlock* bblock) {
+  auto it = std::find(succ_bblock_.begin(), succ_bblock_.end(), bblock);
+  if (it == succ_bblock_.end()) {
+    succ_bblock_.push_back(bblock);
+  }
+}
+
+void MachineBlock::DeletePredBBlock(MachineBlock* bblock) {
+  for (auto it = pred_bblock_.begin();
+      it != pred_bblock_.end();) {
+    if ((*it) == bblock) {
+      it = pred_bblock_.erase(it);
+    } else {
+      it++;
+    }
+  }
+}
+
+void MachineBlock::CopyPredBBlockList(const std::vector<MachineBlock*>& to_copy) {
+  for (auto it : to_copy) {
+    pred_bblock_.push_back(it);
+  }
+}
+
+void MachineBlock::CopySuccBBlockList(const std::vector<MachineBlock*>& to_copy) {
+  for (auto it : to_copy) {
+    succ_bblock_.push_back(it);
+  }
+}
+
+void CFGraph::SetCallDepth(uint32_t depth) {
+  call_depth_ = depth;
+  if (call_depth_ >= kCallDepthLimit) {
+    state_ = AnalysisResult::kCallDepthLimitExceeded;
+  }
+}
+
+void CFGraph::IncBBlockCnt() {
+  ++num_of_bblocks_;
+  if (num_of_bblocks_ > kBasicBlockLimit) {
+    state_ = AnalysisResult::kBasicBlockLimitExceeded;
+  }
+}
+
+void CFGraph::IncreaseInstructionCnt(uint32_t amount) {
+  num_of_instrs_ += amount;
+  if (num_of_instrs_ > kInstructionLimit) {
+    state_ = AnalysisResult::kInstructionLimitExceeded;
+  }
+}
+
+MachineBlock* CFGraph::CreateBBlock(MachineBlock* predecessor_bb, const uint8_t* function_start) {
+  MachineBlock* new_bb = new MachineBlock(predecessor_bb, function_start);
+  new_bb->SetId(GetBBlockCnt());
+  new_bb->SetStartAddr(nullptr);
+  new_bb->SetEndAddr(nullptr);
+  IncBBlockCnt();
+  cfg_bblock_list_.push_back(new_bb);
+  return new_bb;
+}
+
+void CFGraph::AddTuple(MachineBlock* bblock, const uint8_t* start, const uint8_t* end) {
+  bblock->SetStartAddr(start);
+  bblock->SetEndAddr(end);
+  visited_bblock_list_.push_back(bblock);
+  IncreaseInstructionCnt(bblock->GetInstrCnt());
+}
+
+bool CallGraph::HasCycles(std::unique_ptr<CallGraph> graph) {
+  if (graph->root == nullptr) {
+    return false;
+  }
+  return graph->SubgraphCheckCycles(graph->root);
+}
+
+void CallGraph::AddCall(const uint8_t* caller, const uint8_t* callee) {
+  auto caller_entry = GetOrAddCallEntry(caller);
+  auto callee_entry = GetOrAddCallEntry(callee);
+  if (root == nullptr) {
+    root = caller_entry;
+  }
+  caller_entry->AddCallee(callee_entry);
+}
+
+bool CallGraph::SubgraphCheckCycles(CallEntry* node) {
+  // The classic algorithm for checking a directed graph for the presence of cycles in it.
+  if (node->state == NodeState::kAlreadyChecked) {
+    return false;
+  }
+  if (node->state == NodeState::kInCurrentPath) {
+    return true;
+  }
+
+  node->state = NodeState::kInCurrentPath;
+  for (auto& child : node->callees) {
+    if (SubgraphCheckCycles(child)) {
+      return true;
+    }
+  }
+
+  node->state = NodeState::kAlreadyChecked;
+  return false;
+}
+
+CallGraph::CallEntry* CallGraph::GetOrAddCallEntry(const uint8_t* entry_start_address) {
+  auto it = entries.find(entry_start_address);
+  if (it != entries.end()) {
+    return it->second.get();
+  }
+  auto new_entry = std::unique_ptr<CallEntry>(new CallEntry(entry_start_address));
+  auto new_entry_ptr = new_entry.get();
+  entries[entry_start_address] = std::move(new_entry);
+  return new_entry_ptr;
+}
+
+}  // namespace x86
+}  // namespace art

--- a/runtime/binary_analyzer/binary_analyzer_x86.h
+++ b/runtime/binary_analyzer/binary_analyzer_x86.h
@@ -1,0 +1,711 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ART_RUNTIME_BINARY_ANALYZER_BINARY_ANALYZER_X86_H_
+#define ART_RUNTIME_BINARY_ANALYZER_BINARY_ANALYZER_X86_H_
+
+#include <iostream>
+#include <list>
+#include <ostream>
+#include <set>
+#include <string>
+#include <sys/uio.h>
+#include <tuple>
+
+#include "art_field-inl.h"
+#include "art_method-inl.h"
+//namespace capstone {
+//#include "utils.h"
+//}
+namespace capstone{
+// Make sure capstone does not pollute the global namespace.
+extern "C" {
+#include <capstone.h>
+}
+}
+using namespace capstone;
+
+#include "base/logging.h"
+#include "disassembler.h"
+#include "mirror/class-inl.h"
+#include "mirror/class_loader.h"
+#include "mirror/object-inl.h"
+#include "mirror/object_array-inl.h"
+#include "mirror/string-inl.h"
+#include "mirror/throwable.h"
+/*#include "utils/assembler.h"*/
+
+namespace art {
+namespace x86 {
+
+/**
+ * @brief The instruction class stores information about
+ * the decoded/analyzed binary instruction.
+ */
+class MachineInstruction {
+ public:
+  MachineInstruction(std::string instruction_str, uint8_t length, const uint8_t* ptr)
+      : instr_(instruction_str), instr_ptr_(ptr), length_(length) {
+  }
+
+  ~MachineInstruction() {}
+
+  /**
+   * @brief prints the decoded x86 instruction in human readable/dot format to logcat.
+   * @param output - output stream.
+   * @param is_dot - whether the output must be in dot format.
+   */
+  void Print(std::ostream& output, bool is_dot);
+
+  /**
+   * @brief prints the decoded x86 instruction in human readable/dot format.
+   * @param is_dot - whether the output must be in dot format.
+   * @return the output stream.
+   */
+  std::ostringstream Print(bool is_dot);
+
+  /**
+   * @brief returns the human readable x86 instruction.
+   * @return the decoded x86 instruction.
+   */
+  const std::string& GetInstruction() const {
+    return instr_;
+  }
+
+  /**
+   * @brief Get the number of bytes of assembly instruction.
+   * @return the number of bytes the instruction consumes.
+   */
+  uint8_t GetLength() const {
+    return length_;
+  }
+
+  /**
+   * @brief Get the pointer to the instruction.
+   * @return the byte pointer to the x86 assembly code.
+   */
+  const uint8_t* GetInstructionPtr() const {
+    return instr_ptr_;
+  }
+
+  /**
+   * @brief Get the previous Instruction pointer.
+   * @return the previous instruction's pointer.
+   */
+  const MachineInstruction* GetPrevInstruction() {
+    return prev_instr_;
+  }
+
+  /**
+   * @brief Get the next Instruction pointer.
+   * @return the next instruction's pointer.
+   */
+  MachineInstruction* GetNextInstruction() {
+    return next_instr_;
+  }
+
+  /**
+   * @brief Set the previous instruction pointer for the current Instruction.
+   * @param prev the previous instruction pointer.
+   */
+  void SetPrevInstruction(MachineInstruction* prev) {
+    prev_instr_ = prev;
+  }
+
+  /**
+   * @brief Set the next instruction pointer for the current Instruction.
+   * @param next the next instruction pointer.
+   */
+  void SetNextInstruction(MachineInstruction* next) {
+    next_instr_ = next;
+  }
+
+ private:
+  std::string instr_;
+  const uint8_t* instr_ptr_;
+  uint8_t length_;
+  MachineInstruction* prev_instr_;
+  MachineInstruction* next_instr_;
+};
+
+/**
+ * @brief BBlock class contains information about a Basic Block.
+ * Note : A dummy basic block is the one that connects a basic block
+ * that ends with a call instruction to the starting of the call site
+ * Basic Block. A dummy basic block does not contain any instructions.
+ * It merely serves as a link.
+ */
+class MachineBlock {
+ public:
+  explicit MachineBlock(MachineBlock* pred_bb, const uint8_t* function_start_addr)
+      : num_of_instrs_(0),
+        is_dummy_(false) {
+    function_start_addr_ = function_start_addr;
+    if (pred_bb != nullptr) {
+      AddPredBBlock(pred_bb);
+      pred_bb->AddSuccBBlock(this);
+    }
+    id_ = -1;
+    start_addr_ = nullptr;
+    end_addr_ = nullptr;
+  }
+
+  ~MachineBlock();
+
+  /**
+   * @brief Get the last Instruction class pointer for the Basic Block.
+   * @return the pointer to the last Instruction of the Basic Block.
+   */
+  MachineInstruction* GetLastInstruction() const {
+    if (!instrs_.empty()) {
+      return instrs_.back();
+    }
+    return nullptr;
+  }
+
+  /**
+   * @brief Set the starting address of the Basic Block.
+   * @param start - Starting address of the Basic Block.
+   */
+  void SetStartAddr(const uint8_t* start) {
+    start_addr_ = start;
+    if (function_start_addr_ == nullptr) {
+      function_start_addr_ = start; // Probably we are the first in CFG.
+    }
+  }
+
+  /**
+   * @brief Get the starting address of the Basic Block.
+   * @return Starting address of the Basic Block.
+   */
+  const uint8_t* GetStartAddr() const {
+    return start_addr_;
+  }
+
+  /**
+   * @brief Set the ending address of the Basic Block.
+   * @param end - Ending address of the Basic Block.
+   */
+  void SetEndAddr(const uint8_t* end) {
+    end_addr_ = end;
+  }
+
+  /**
+   * @brief Get the ending address of the Basic Block.
+   * @return Ending address of the Basic Block.
+   */
+  const uint8_t* GetEndAddr() const {
+    return end_addr_;
+  }
+
+  /**
+  * @param start - address of the first instruction of the function which this Basic Block belongs.
+   * @brief Set start of the function which this Basic Block belongs.
+   */
+  void SetFunctionStartAddr(const uint8_t* start) {
+    function_start_addr_ = start;
+  }
+
+  /*
+   * @brief Get start of the function which this Basic Block belongs.
+   * @return Address of the first instruction of this function.
+   */
+  const uint8_t* GetFunctionStartAddr() const {
+    return function_start_addr_;
+  }
+
+  /**
+   * @brief Set this Basic Block as Dummy.
+   */
+  void SetDummy() {
+    is_dummy_ = true;
+  }
+
+  /**
+   * @brief Is this Basic Block a dummy.
+   * @return whether the basic block is a dummy or not.
+   */
+  bool IsDummy() const {
+    return is_dummy_;
+  }
+
+  /**
+   * @brief Get the number of Instructions.
+   * @return number of Instructions in the Basic Block.
+   */
+  uint32_t GetInstrCnt() const {
+    return num_of_instrs_;
+  }
+
+  /**
+   * @brief Get The Id of this Basic Block.
+   * @return the Basic Block's id.
+   */
+  uint32_t GetId() const {
+    return id_;
+  }
+
+  /**
+   * @brief Set the Basic Block's Id.
+   * @param - the Id for the Basic Block.
+   */
+  void SetId(uint32_t id) {
+    id_ = id;
+  }
+
+  /**
+   * @brief Add the Instruction to the Basic Block.
+   * @param instruction - The instruction to be added to the Basic Block.
+   */
+  void AddInstruction(MachineInstruction* instruction) {
+    instrs_.push_back(instruction);
+    ++num_of_instrs_;
+  }
+
+  /**
+   * @brief Add a Basic Block to list of predecessor Basic Blocks.
+   * @param bblock - the predecessor Basic Block.
+   */
+  void AddPredBBlock(MachineBlock* bblock);
+
+  /**
+   * @brief Add a Basic Block to list of successor Basic Blocks.
+   * @param bblock - the successor Basic Block.
+   */
+  void AddSuccBBlock(MachineBlock* bblock);
+
+  /**
+   * @brief Delete a certain Basic Block from the list of predecessor Basic Blocks.
+   * @param bblock - the Basic Block to be deleted.
+   */
+  void DeletePredBBlock(MachineBlock* bblock);
+
+  /**
+   * Get the list of predecessor Basic Blocks.
+   * @return the predecessor Basic Block List.
+   */
+  const std::vector<MachineBlock*>& GetPredBBlockList() const {
+    return pred_bblock_;
+  }
+
+  /**
+   * Get the list of successor Basic Blocks.
+   * @return the successor Basic Block List.
+   */
+  const std::vector<MachineBlock*>& GetSuccBBlockList() const {
+    return succ_bblock_;
+  }
+
+  /**
+   * @brief Make a copy of the array of predecessor Basic Blocks.
+   * @param to_copy - The vector that contain predecessor Basic Blocks to be copied.
+   */
+  void CopyPredBBlockList(const std::vector<MachineBlock*>& to_copy);
+
+  /**
+   * @brief Make a copy of the array of successor Basic Blocks.
+   * @param to_copy - The vector that contain successor Basic Blocks to be copied.
+   */
+  void CopySuccBBlockList(const std::vector<MachineBlock*>& to_copy);
+
+  /**
+   * @brief Clear the array of predecessor Basic Blocks.
+   */
+  void ClearPredBBlockList() {
+    pred_bblock_.clear();
+  }
+
+  /**
+   * @brief Clear the array of successor Basic Blocks.
+   */
+  void ClearSuccBBlockList() {
+    succ_bblock_.clear();
+  }
+
+  /**
+   * @brief Get the Instruction Class Pointer List for the Basic Block.
+   * @return The Instruction class pointer list.
+   */
+  const std::list<MachineInstruction*>& GetInstructions() const {
+    return instrs_;
+  }
+
+  /**
+   * @brief prints the info on Basic Block in human readable/dot format to logcat.
+   * @param output - output stream.
+   * @param is_dot - whether the output must be in dot format.
+   */
+  void Print(std::ostream& output, bool is_dot);
+
+  /**
+   * @brief prints the info on Basic Block in human readable/dot format.
+   * @param is_dot - whether the output must be in dot format.
+   * @return the output stream.
+   */
+  std::ostringstream Print(bool is_dot);
+
+  /**
+   * @brief Copies the Instructions Starting from a certain Address to the Basic Block.
+   * @param from_bblock - the Basic Block from which Instructions have to be copied.
+   * @param start - The starting pointer to the Instruction Class.
+   */
+  void CopyInstruction(MachineBlock* from_bblock, const uint8_t* start);
+
+  /**
+   * @brief Deletes a certain Instruction from the Basic Block.
+   * @param it - iterator for the Instruction List.
+   */
+  void DeleteInstruction(std::list<MachineInstruction*>::iterator it);
+
+ private:
+  uint32_t id_;
+  const uint8_t* function_start_addr_;
+  const uint8_t* start_addr_;
+  const uint8_t* end_addr_;
+  uint32_t num_of_instrs_;
+  std::vector<MachineBlock*> pred_bblock_;
+  std::vector<MachineBlock*> succ_bblock_;
+  std::list<MachineInstruction*> instrs_;
+  bool is_dummy_;
+};
+
+/**
+ * The BackLogDs Data Structure stores the code paths that have not yet been
+ * analyzed. This could be due to call, jump (conditional/unconditional) etc.
+ */
+struct BackLogDs {
+  MachineBlock* pred_bb;
+  const uint8_t* ptr;
+  MachineBlock* succ_bb;
+  const uint8_t* function_start;
+  bool is_function_start;
+  uint32_t call_depth;
+};
+
+/**
+ * Call graph used to detect recursion since we disabled detection of cycles
+ * on CFG level (it was replaced with heuristic which cannot detect recursion).
+ */
+class CallGraph {
+  struct CallEntry;
+ public:
+  CallGraph(CallGraph&& other) = default;
+  CallGraph& operator=(CallGraph&& other) = default;
+
+  static std::unique_ptr<CallGraph> CreateNew() {
+    return std::unique_ptr<CallGraph>(new CallGraph);
+  }
+
+  static bool HasCycles(std::unique_ptr<CallGraph> graph);
+
+  void AddCall(const uint8_t* caller, const uint8_t* callee);
+
+ private:
+  enum class NodeState {
+    kNotVisited,     // Not visited node.
+    kInCurrentPath,  // Already visited during current sub-path.
+    kAlreadyChecked, // Node from checked subgraph.
+  };
+
+  struct CallEntry {
+    CallEntry(const uint8_t* call_entry_address)
+        : call_entry_addr(call_entry_address) {}
+
+    void AddCallee(CallEntry* callee) {
+      callees.insert(callee);
+    }
+
+    const uint8_t* const call_entry_addr;
+    std::unordered_set<CallEntry*> callees;
+    NodeState state = NodeState::kNotVisited;
+  };
+
+  DISALLOW_COPY_AND_ASSIGN(CallGraph);
+  CallGraph() = default;
+
+  bool SubgraphCheckCycles(CallEntry* node);
+  CallEntry* GetOrAddCallEntry(const uint8_t* entry_start_address);
+
+  CallEntry* root = nullptr;
+  std::unordered_map<const uint8_t*, std::unique_ptr<CallEntry>> entries;
+};
+
+enum class AnalysisResult {
+  kFast,
+  kHasLocks,
+  kHasCycles,
+  kHasInterrupts,
+  kHasIndirectCalls,
+  kHasIndirectJumps,
+  kHasUnknownInstructions,
+  kCallDepthLimitExceeded,
+  kBasicBlockLimitExceeded,
+  kInstructionLimitExceeded,
+};
+
+inline const char* AnalysisResultToStr(AnalysisResult res) {
+  switch (res) {
+    case AnalysisResult::kFast:
+      return "fast";
+    case AnalysisResult::kHasLocks:
+      return "has locks";
+    case AnalysisResult::kHasCycles:
+      return "has cycles";
+    case AnalysisResult::kHasInterrupts:
+      return "has interrupts";
+    case AnalysisResult::kHasIndirectCalls:
+      return "has indirect calls";
+    case AnalysisResult::kHasIndirectJumps:
+      return "has indirect jumps";
+    case AnalysisResult::kHasUnknownInstructions:
+      return "has unknown instructions";
+    case AnalysisResult::kCallDepthLimitExceeded:
+      return "exceeds call depth limit";
+    case AnalysisResult::kBasicBlockLimitExceeded:
+      return "exceeds basic block limit";
+    case AnalysisResult::kInstructionLimitExceeded:
+      return "exceeds instruction limit";
+    default:
+      LOG(ERROR) << "Unknown auto fast JNI analysis result!";
+      return "";
+  }
+}
+
+/**
+ * CFGraph Class has information about the Control Flow Graph.
+ */
+class CFGraph {
+ public:
+  explicit CFGraph(std::string method_name)
+      : method_name_(method_name) {}
+
+  ~CFGraph() {
+    for (auto it : cfg_bblock_list_) {
+      delete it;
+    }
+  }
+
+  /**
+   * @brief Delete a certain Basic Block & Add a certain Basic Block from & to a
+   * list of Basic Blocks respectively.
+   * @param bblock_list - the list from which a Basic Block has to deleted &
+   * to which a Basic Block has to be added.
+   * @param bblock_to_be_deleted - the Basic Block to be deleted.
+   * @param bblock_to_be_added - the Basic Block to de added.
+   */
+  void ChangePredecessors(const std::vector<MachineBlock*> &bblock_list,
+                          MachineBlock* bblock_to_be_deleted,
+                          MachineBlock* bblock_to_be_added);
+
+  /**
+   * In case a Basic Block is a dummy, returns it's predecessor.
+   * @param bblock - the Basic Block which is being tested.
+   * @return bblock itself if not dummy; else returns it's predecessor.
+   */
+  MachineBlock* GetCorrectBB(MachineBlock* bblock);
+
+  /**
+   * @brief Get the name of the method being analyzed.
+   * @return the method's PrettyName.
+   */
+  const std::string& GetMethodName() const {
+    return method_name_;
+  }
+
+  void SetHasUnknownInstructions() {
+    state_ = AnalysisResult::kHasUnknownInstructions;
+  }
+
+  void SetHasCycles() {
+    state_ = AnalysisResult::kHasCycles;
+  }
+
+  void SetHasLocks() {
+    state_ = AnalysisResult::kHasLocks;
+  }
+
+  void SetHasIndirectJumps() {
+    state_ = AnalysisResult::kHasIndirectJumps;
+  }
+
+  void SetHasInterrupts() {
+    state_ = AnalysisResult::kHasInterrupts;
+  }
+
+  void SetHasIndirectCalls() {
+    state_ = AnalysisResult::kHasIndirectCalls;
+  }
+
+  /**
+   * @brief Get the levels of call nesting.
+   * @return the levels of call nesting.
+   */
+  uint32_t GetCallDepth() const {
+    return call_depth_;
+  }
+
+  /**
+   * @brief Sets the call nesting level (and checks if we are still in budget)
+   * @param depth - the level of call nesting.
+   */
+  void SetCallDepth(uint32_t depth);
+
+  /**
+   * @brief Get the Number of Instructions in the CFG.
+   * @return the number of Instructions.
+   */
+  uint32_t GetInstructionCnt() const {
+    return num_of_instrs_;
+  }
+
+  /**
+   * @brief Increase instruction count by the given amount (and check if we are still in budget).
+   * @param amount - amount of added instructions.
+   */
+  void IncreaseInstructionCnt(uint32_t amount);
+
+  /**
+   * @brief Get the Number of Basic Blocks in the CFG.
+   * @return the number of Basic Blocks.
+   */
+  uint32_t GetBBlockCnt() const {
+    return num_of_bblocks_;
+  }
+
+  /**
+   * @brief Increment basic block count (and check if we are still in budget)
+   */
+  void IncBBlockCnt();
+
+  /**
+   * @brief Add a Basic Block as the Starting Basic Block for CFG.
+   * @param start_bblock - the starting Basic Block.
+   */
+  void AddStartBBlock(MachineBlock* start_bblock) {
+    start_bblock_ = start_bblock;
+  }
+
+  /**
+   * @brief Creates a Basic Block in the CFG & updates the predecessor.
+   * @param predecessor_bblock - Predecessor Basic Block.
+   * @return the created Basic Block.
+   */
+  MachineBlock* CreateBBlock(MachineBlock* predecessor_bblock, const uint8_t* function_start);
+
+  /**
+   * @brief Update the Predecessors & successors caused by backlog due
+   * to calls/jumps in the CFG.
+   * @param old_pred - The old predecessor to be updated.
+   * @param new_pred - The new predecessor.
+   * @param backlog - List of backlog Data Structure.
+   */
+  void ChangePredForBacklog(MachineBlock* old_pred,
+                            MachineBlock* new_pred,
+                            std::vector<BackLogDs*>* backlog);
+
+  /**
+   * @brief Get the First Basic Block of the CFG.
+   * @return The first Basic Block.
+   */
+  MachineBlock* GetStartBBlock() {
+    return start_bblock_;
+  }
+
+  /**
+   * @brief Keeps track of visited Basic Blocks.
+   * @param bblock - the Basic Block that was visited.
+   * @param start - Starting instruction pointer.
+   * @param end - ending instruction pointer.
+   */
+  void AddTuple(MachineBlock* bblock, const uint8_t* start, const uint8_t* end);
+
+  /**
+   * @brief Check whether the Basic Block was already visited.
+   * @param addr - the pointer to a certain location that has to be tested.
+   * @param prev_bblock - Predecessor Basic Block.
+   * @return true if visited. False otherwise.
+   */
+  bool IsVisitedForCall(uint8_t* addr, MachineBlock* prev_bblock) const;
+
+  /**
+   * @brief Check if an entry in the backlog was analyzed already.
+   * @param entry - the backlog entry.
+   * @param backlog - list of backlog entries.
+   * @return true of visited; false otherwise.
+   */
+  bool IsVisitedForBacklog(BackLogDs* entry, std::vector<BackLogDs*>* backlog);
+
+  /**
+   * @brief Check if a certain location(instruction) was already analyzed or not.
+   * @param addr - The address that is being checked.
+   * @param prev_bblock - Predecessor Basic Block.
+   * @param succ_bblock - Successor Basic Block.
+   * @param backlog - List of backlog entries.
+   * @param is_function_start - True if it is the first instruction in function otherwise false.
+   * @return true if analyzed already; false otherwise.
+   */
+  bool IsVisited(const uint8_t* addr,
+                 MachineBlock* prev_bblock,
+                 MachineBlock* succ_bblock,
+                 std::vector<BackLogDs*>* backlog,
+                 const bool is_function_start);
+
+  /**
+   * @brief prints the CFG in human readable/dot format to logcat.
+   * @param output - output stream.
+   * @param is_dot - whether the output must be in dot format.
+   */
+  void Print(std::ostringstream &output, bool is_dot) const;
+
+  /**
+   * @brief Determine if the CFG falls within the budget to call it Fast or not.
+   * @return true if method's CFG satisfies budget; false otherwise.
+   */
+  bool IsStillFast() const;
+
+  /**
+   * @brief Get the current state of CFG analysis.
+   * @return Current state of analysis.
+   */
+  AnalysisResult GetAnalysisState() const {
+    return state_;
+  }
+
+ private:
+  MachineBlock* start_bblock_;
+  uint32_t num_of_bblocks_ = 0u;
+  uint32_t num_of_instrs_ = 0u;
+  uint32_t call_depth_ = 0u;
+  AnalysisResult state_ = AnalysisResult::kFast;
+  std::vector<MachineBlock*> cfg_bblock_list_;
+  std::vector<MachineBlock*> visited_bblock_list_;
+  std::string method_name_;
+};
+
+/**
+ * @brief Analyze a method and determine whether it can be marked fast or not.
+ * @param method_idx - dex method Index.
+ * @param dex_file - dex File.
+ * @param fn_ptr - Function pointer of method to be analyzed.
+ * @return true if fast; false otherwise.
+ */
+AnalysisResult AnalyzeMethod(uint32_t method_idx, const DexFile& dex_file, const void* fn_ptr);
+
+}  // namespace x86
+}  // namespace art
+
+#endif  // ART_RUNTIME_BINARY_ANALYZER_BINARY_ANALYZER_X86_H_
+

--- a/runtime/binary_analyzer/disassembler.cc
+++ b/runtime/binary_analyzer/disassembler.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "arch/instruction_set.h"
+#include "base/logging.h"
+#include "disassembler.h"
+
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+
+namespace art {
+
+Disassembler::Disassembler(InstructionSet insn_set) {
+  ptr_ = nullptr;
+  address_ = 0;
+  // Instantiate a capstone handle/instance.
+  switch (insn_set) {
+  case InstructionSet::kX86:
+    err_ = cs_open(CS_ARCH_X86, CS_MODE_32, &handle_);
+    break;
+
+  case InstructionSet::kX86_64:
+    err_ = cs_open(CS_ARCH_X86, CS_MODE_64, &handle_);
+    if (err_) {
+	LOG(ERROR) << "Failed on cs_open() with error:" << cs_strerror(err_);
+    }
+    break;
+
+  default:
+    err_ = CS_ERR_ARCH;
+    return;
+  }
+
+  if (err_ != CS_ERR_OK) {
+    return;
+  }
+
+  err_ = cs_option(handle_, CS_OPT_DETAIL, CS_OPT_ON);
+
+  if (err_ != CS_ERR_OK) {
+    return;
+  }
+
+  // Allocate memory for the the iterator.
+  insn_ = cs_malloc(handle_);
+
+  if (insn_ == nullptr) {
+    err_ = CS_ERR_MEM;
+  }
+}
+
+Disassembler::~Disassembler() {
+  if (insn_ != nullptr) {
+    cs_free(insn_, 1);
+  }
+
+  cs_close(&handle_);
+}
+
+}  // namespace art

--- a/runtime/binary_analyzer/disassembler.h
+++ b/runtime/binary_analyzer/disassembler.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ART_RUNTIME_BINARY_ANALYZER_DISASSEMBLER_H_
+#define ART_RUNTIME_BINARY_ANALYZER_DISASSEMBLER_H_
+
+#include "arch/instruction_set.h"
+#include <cstddef>
+
+
+namespace capstone{
+// Make sure capstone does not pollute the global namespace.
+extern "C" {
+#include <capstone.h>
+}
+}
+using namespace capstone;
+
+namespace art {
+/**
+ * @brief The Disassembler class is a wrapper around the capstone disassembly library.
+ * The Disassembler can be viewed as a iterator which walks a binary stream and returns
+ * a cs_insn object each time the iterator is invoked. The Disassembler maintains both
+ * a user-specified address and a pointer (the address being useful in cases in which
+ * the address at which stream might get linked/placed at is different than the current
+ * location of the stream on the host).
+ */
+class Disassembler {
+ public:
+  explicit Disassembler(InstructionSet insn_set);
+  ~Disassembler();
+
+  /**
+   * @brief Returns the address of the head of the stream (that is, the address of the
+   * stream that the user indicated when the last Seek operation was performed).
+   *
+   * @return Address of the head of the stream.
+   */
+  uint64_t GetAddress() const {
+    return address_;
+  }
+
+  /**
+   * @brief Returns a pointer corresponding to the head of the binary stream.
+   *
+   * @return Pointer to the head of the strema.
+   */
+  const uint8_t* GetPtr() const {
+    return ptr_;
+  }
+
+  /**
+   * @brief Checks if the Disassembler was constructed successfully. The constructor
+   * will fail if the library was not configured for the requested architecture.
+   *
+   * @return true if the Disassembler is ready for use; false otherwise.
+   */
+  bool IsDisassemblerValid() const {
+    return err_ == CS_ERR_OK;
+  }
+
+  /**
+   * @brief Diassembles the next instruction in the binary stream. The contents of any
+   * prior cs_insn returned by this method will have its contents overwritten.
+   *
+   * @return A cs_insn object that is populated with details about the next instruction.
+   */
+  const cs_insn* Next() {
+    size_t sz = std::numeric_limits<size_t>::max();
+    if (UNLIKELY(!cs_disasm_iter(handle_, &ptr_, &sz, &address_, insn_))) {
+      return nullptr;
+    }
+
+    return insn_;
+  }
+
+  /**
+   * @brief Positions the iterator head at ptr and sets the user-specified address to ptr.
+   */
+  void Seek(const uint8_t* ptr) {
+    Seek(ptr, reinterpret_cast<uint64_t>(ptr));
+  }
+
+  /**
+   * @brief Positions the iterator head at ptr and sets the user-specified address.
+   */
+  void Seek(const uint8_t* ptr, uint64_t address) {
+    ptr_ = ptr;
+    address_ = address;
+  }
+
+ private:
+  uint64_t address_;
+  const uint8_t* ptr_;
+  cs_insn* insn_;
+  csh handle_;
+  cs_err err_;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(Disassembler);
+};
+
+}  // namespace art
+
+#endif  // ART_RUNTIME_BINARY_ANALYZER_DISASSEMBLER_H_

--- a/runtime/entrypoints/jni/jni_entrypoints.cc
+++ b/runtime/entrypoints/jni/jni_entrypoints.cc
@@ -27,27 +27,40 @@ namespace art {
 
 // Used by the JNI dlsym stub to find the native method to invoke if none is registered.
 #if defined(__arm__) || defined(__aarch64__)
-extern "C" const void* artFindNativeMethod() {
+extern "C" void* artFindNativeMethod() NO_THREAD_SAFETY_ANALYSIS {
   Thread* self = Thread::Current();
 #else
-extern "C" const void* artFindNativeMethod(Thread* self) {
+extern "C" const void* artFindNativeMethod(Thread* self) NO_THREAD_SAFETY_ANALYSIS {
   DCHECK_EQ(self, Thread::Current());
 #endif
-  Locks::mutator_lock_->AssertNotHeld(self);  // We come here as Native.
-  ScopedObjectAccess soa(self);
+  bool was_slow = false;
+  bool is_fast = false;
+  const void* return_val = nullptr;
+  {
+    Locks::mutator_lock_->AssertNotHeld(self);  // We come here as Native.
+    ScopedObjectAccess soa(self);
 
-  ArtMethod* method = self->GetCurrentMethod(nullptr);
-  DCHECK(method != nullptr);
+    ArtMethod* method = self->GetCurrentMethod(nullptr);
+    DCHECK(method != nullptr);
 
-  // Lookup symbol address for method, on failure we'll return null with an exception set,
-  // otherwise we return the address of the method we found.
-  void* native_code = soa.Vm()->FindCodeForNativeMethod(method);
-  if (native_code == nullptr) {
-    self->AssertPendingException();
-    return nullptr;
+    // Lookup symbol address for method, on failure we'll return null with an exception set,
+    // otherwise we return the address of the method we found.
+    void* native_code = soa.Vm()->FindCodeForNativeMethod(method);
+    if (native_code == nullptr) {
+      self->AssertPendingException();
+      return nullptr;
+    } else {
+      // Register so that future calls don't come here
+      was_slow = !method->IsFastNative();
+      const void* final_function_ptr = method->RegisterNative(native_code);
+      is_fast = method->IsFastNative();
+      return_val = final_function_ptr;
+    }
   }
-  // Register so that future calls don't come here
-  return method->RegisterNative(native_code);
+  if (was_slow && is_fast) {
+    self->TransitionFromSuspendedToRunnable();
+  }
+  return return_val;
 }
 
 }  // namespace art

--- a/runtime/jit/jit.cc
+++ b/runtime/jit/jit.cc
@@ -739,6 +739,14 @@ void Jit::MethodEntered(Thread* thread, ArtMethod* method) {
   }
 }
 
+bool Jit::AddJniTask(Thread* self, JniTask* task) {
+  if (thread_pool_ == nullptr) {
+    return false;
+  }
+  thread_pool_->AddTask(self, task);
+  return true;
+}
+
 void Jit::InvokeVirtualOrInterface(ObjPtr<mirror::Object> this_object,
                                    ArtMethod* caller,
                                    uint32_t dex_pc,

--- a/runtime/jit/jit.h
+++ b/runtime/jit/jit.h
@@ -41,6 +41,7 @@ namespace jit {
 
 class JitCodeCache;
 class JitOptions;
+class JniTask : public Task { };
 
 static constexpr int16_t kJitCheckForOSR = -1;
 static constexpr int16_t kJitHotnessDisabled = -2;
@@ -175,7 +176,8 @@ class Jit {
 
   // Start JIT threads.
   void Start();
-
+  bool AddJniTask(Thread* self, JniTask* task);
+ 
  private:
   Jit();
 

--- a/runtime/runtime.cc
+++ b/runtime/runtime.cc
@@ -72,6 +72,9 @@
 #include "base/utils.h"
 #include "class_linker-inl.h"
 #include "compiler_callbacks.h"
+#ifdef __ANDROID__
+#include "cutils/properties.h"
+#endif
 #include "debugger.h"
 #include "dex/art_dex_file_loader.h"
 #include "dex/dex_file_loader.h"
@@ -879,7 +882,28 @@ void Runtime::InitNonZygoteOrPostFork(
     const char* isa,
     bool profile_system_server) {
   is_zygote_ = false;
-
+#ifdef CAPSTONE
+#ifdef __ANDROID__
+  char property_value[PROPERTY_VALUE_MAX];
+  property_get("persist.dalvik.autofast.disable", property_value, "false");
+  SetAutoFastDetect(strcmp(property_value, "true") != 0);
+  property_get("persist.dalvik.autofast.debug", property_value, "false");
+  gLogVerbosity.autofast_jni = (strcmp(property_value, "true") == 0);
+#else
+  const char* autofast_disable = getenv("ART_AUTOFAST_DISABLE");
+  if (autofast_disable != nullptr) {
+    SetAutoFastDetect(strcmp(autofast_disable, "true") != 0);
+  } else {
+    SetAutoFastDetect(false);
+  }
+  const char* autofast_debug = getenv("ART_AUTOFAST_DEBUG");
+  if (autofast_debug != nullptr) {
+    gLogVerbosity.autofast_jni = (strcmp(autofast_debug, "true") == 0);
+  } else {
+    gLogVerbosity.autofast_jni = false;
+  }
+#endif
+#endif
   if (is_native_bridge_loaded_) {
     switch (action) {
       case NativeBridgeAction::kUnload:

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -728,6 +728,19 @@ class Runtime {
     return env_snapshot_.GetSnapshot();
   }
 
+#ifdef CAPSTONE
+  // Should Auto fast Detection be done.
+  bool IsAutoFastDetect() const {
+    return auto_fast_detect_;
+  }
+
+  // Set Auto Fast Detection.
+  void SetAutoFastDetect(bool value) {
+    auto_fast_detect_ = value;
+  }
+#endif
+
+
   void AddSystemWeakHolder(gc::AbstractSystemWeakHolder* holder);
   void RemoveSystemWeakHolder(gc::AbstractSystemWeakHolder* holder);
 
@@ -1095,6 +1108,11 @@ class Runtime {
       static_cast<uint32_t>(DeoptimizationKind::kLast) + 1];
 
   std::unique_ptr<MemMap> protected_fault_page_;
+#ifdef CAPSTONE
+  // Auto Fast JNI detection gate.
+  bool auto_fast_detect_;
+#endif
+
 
   DISALLOW_COPY_AND_ASSIGN(Runtime);
 };


### PR DESCRIPTION
This patch implements Binary Analysis for x86 during native method registration at runtime. The method is classified as fast if it
satisfies certain budget constraints - No indirect calls, No more than 3 levels of call nesting, No unsupported instructions, interrupts
or repeats, less than or equal to 20 Basic Blocks & 100 Instructions.
Disassembly of x86 Instructions is done using the Capstone Library.If the Capstone library is not present, this feature is disabled.
The auto fast JNI is enabled by default.In AOT mode we can't use thread pool from JIT whilst fast JNI detection in main thread is unacceptable due to its impact on app launch time,
so this will be disabled in AOT mode.

Change-Id: Ib24749bcecaa458e42d2f6e9f408209b0a8a67e7
Category: device enablement
Domain: AOSP.ART-Other
Origin: internal
Upstream-Candidate: no, proprietary
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68865
Signed-off-by: Priyanka Bose <priyanka.bose@intel.com>
Reviewed-on: https://android.intel.com:443/645900