### PR TITLE
Fix a bug in instruction_simplifier_x86 pass when avx2 is enabled

### DIFF
--- a/compiler/optimizing/instruction_simplifier_x86_shared.cc
+++ b/compiler/optimizing/instruction_simplifier_x86_shared.cc
@@ -32,6 +32,8 @@ bool TryCombineAndNot(HNot* instruction) {
    // and thus can be safely removed.
    if (instruction->HasOnlyOneNonEnvironmentUse()) {
      HInstruction* use = instruction->GetUses().front().GetUser();
+     if (!use->IsAnd())
+       return false;
      HAnd* and_ins = use->AsAnd();
      HInstruction* left = and_ins->GetLeft();
      HInstruction* right = and_ins->GetRight();


### PR DESCRIPTION
Tracked-On: OAM-75397
Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>