### PR TITLE
Strength Reduction in Induction Variables

### DIFF
--- a/compiler/Android.bp
+++ b/compiler/Android.bp
@@ -61,6 +61,7 @@ art_cc_defaults {
         "optimizing/gvn.cc",
         "optimizing/induction_var_analysis.cc",
         "optimizing/induction_var_range.cc",
+        "optimizing/iv_simplifier.cc",
         "optimizing/inliner.cc",
         "optimizing/instruction_builder.cc",
         "optimizing/instruction_simplifier.cc",

--- a/compiler/optimizing/induction_var_analysis.h
+++ b/compiler/optimizing/induction_var_analysis.h
@@ -278,6 +278,7 @@ class HInductionVarAnalysis : public HOptimization {
 
   friend class InductionVarAnalysisTest;
   friend class InductionVarRange;
+  friend class InductionVarSimplification;
   friend class InductionVarRangeTest;
 
   DISALLOW_COPY_AND_ASSIGN(HInductionVarAnalysis);

--- a/compiler/optimizing/iv_simplifier.cc
+++ b/compiler/optimizing/iv_simplifier.cc
@@ -1,0 +1,354 @@
+/*
+Copyright (c) 2018 Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+    * this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+    * this list of conditions and the following disclaimer in the documentation
+    * and/or other materials provided with the distribution.
+
+    * Neither the name of Intel Corporation nor the names of its contributors
+    * may be used to endorse or promote products derived from this software
+    * without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "iv_simplifier.h"
+#include<tuple>
+
+namespace art{
+
+
+typedef std::tuple<HInstruction*,HConstant*, HConstant* > triple;
+//
+// public methods
+//
+InductionVarSimplification::InductionVarSimplification(HInductionVarAnalysis* induction_analysis)
+    : induction_analysis_(induction_analysis),
+      biv_increment_(nullptr) {
+  DCHECK(induction_analysis != nullptr);
+}
+
+/*Helper Functions*/
+static HConstant* GetNewConstant(HInstruction::InstructionKind kind, HConstant* cst1, HConstant* cst2) {
+   DataType::Type type = cst1->GetType();
+   HConstant* new_cst = nullptr;
+   HGraph* graph = cst1->GetBlock()->GetGraph();
+   if (DataType::IsIntegralType(type)) {
+     int64_t new_val = 0;
+     switch (kind) {
+      case HInstruction::kAdd :
+      new_val = Int64FromConstant(cst1) + Int64FromConstant(cst2);
+      break;
+      case HInstruction::kSub: 
+      new_val = Int64FromConstant(cst1) - Int64FromConstant(cst2);
+      break;
+      case HInstruction::kMul:
+       new_val = Int64FromConstant(cst1) * Int64FromConstant(cst2);
+       break;
+      default :
+       UNREACHABLE();
+     }
+      new_cst = graph->GetConstant(type, new_val);
+      return new_cst;
+    } else if (cst1->IsDoubleConstant()) {
+      double new_val =0.0;
+      switch (kind){
+        case HInstruction::kAdd:
+        new_val = cst1->AsDoubleConstant()->GetValue() + cst2->AsDoubleConstant()->GetValue();
+        break;
+        case HInstruction::kSub:
+        new_val = cst1->AsDoubleConstant()->GetValue() - (cst2->AsDoubleConstant()->GetValue());
+        break;
+        case HInstruction::kMul:
+        new_val = cst1->AsDoubleConstant()->GetValue() * cst2->AsDoubleConstant()->GetValue();
+        break;
+        default :
+          UNREACHABLE();
+      }
+      new_cst = graph->GetDoubleConstant(new_val);
+      return new_cst;
+    } else if (cst1->IsFloatConstant()) {
+      float new_val = 0.0;
+      switch (kind) {
+       case HInstruction::kAdd:
+        new_val = cst1->AsFloatConstant()->GetValue() + cst2->AsFloatConstant()->GetValue();
+        break;
+       case HInstruction::kSub:
+        new_val = cst1->AsFloatConstant()->GetValue() - cst2->AsFloatConstant()->GetValue();
+        break;
+       case HInstruction::kMul:
+        new_val = cst1->AsFloatConstant()->GetValue() * cst2->AsFloatConstant()->GetValue();
+        break;
+        default:
+          UNREACHABLE();
+      }
+      new_cst = graph->GetFloatConstant( new_val);
+      return new_cst;
+    }
+    return nullptr;
+}
+static HConstant* GetConstant(HGraph* graph, DataType::Type type, int64_t value){
+   HConstant * cst = nullptr;
+   if (DataType::IsIntegralType(type)) {
+      cst = graph->GetConstant(type, value);
+   } else if (type == DataType::Type::kFloat32) {
+     float val = static_cast<float>(value);
+     cst = graph->GetFloatConstant(val);
+   } else if (type == DataType::Type::kFloat64) {
+     double val = static_cast<double>(value);
+     cst = graph->GetDoubleConstant(val);
+   }
+   return cst;
+}
+
+static HConstant* GetNegativeConstant(HGraph* graph, DataType::Type type, HConstant* input) {
+  HConstant* cst = nullptr;
+  if (DataType::IsIntegralType(type)) {
+        int64_t val = Int64FromConstant(input);
+        cst = GetConstant(graph, type, -1*val);
+  } else if (type ==DataType::Type::kFloat32){
+    float val = input->AsFloatConstant()->GetValue();
+    cst = GetConstant(graph, type, -1.0f*val);
+  } else if (type == DataType::Type::kFloat64){
+     double val = input->AsDoubleConstant()->GetValue();
+     cst = GetConstant(graph, type, -1.0f*val);
+  }
+  return cst;
+}
+
+HInstruction* GetOutOfLoopInput(HLoopInformation* loop, HPhi* phi) {
+ HInputsRef inputs = phi->GetInputs();
+ for (size_t i = 0; i < inputs.size(); ++i) {
+   HInstruction* input = inputs[i];
+   if (input->GetBlock()->GetLoopInformation() != loop) {
+    return input;
+   }
+ }
+ return nullptr;
+}
+
+bool InductionVarSimplification::IsCandidatePhi(HLoopInformation* loop, HPhi* phi) {
+  HInputsRef inputs = phi->GetInputs();
+  if (inputs.size() != 2 )
+    return false;
+  HInstruction* control = loop->GetHeader()->GetLastInstruction();
+  HInductionVarAnalysis::InductionInfo* phi_info = induction_analysis_->LookupInfo(loop, phi);
+  if (control->IsIf()) {
+    HIf* ifs = control->AsIf();
+    HInstruction* if_expr = ifs->InputAt(0);
+    // Determine if loop has following structure in header.
+    // loop-header: ....
+    //              if (condition) goto X
+    if (if_expr->IsCondition()) {
+      HCondition* condition = if_expr->AsCondition();
+      HInductionVarAnalysis::InductionInfo* a = induction_analysis_->LookupInfo(loop, condition->InputAt(0));
+      HInductionVarAnalysis::InductionInfo* b = induction_analysis_->LookupInfo(loop, condition->InputAt(1));
+      if (HInductionVarAnalysis::InductionEqual(a,phi_info) || HInductionVarAnalysis::InductionEqual(b, phi_info)) {
+       // check if it is incremented by a constant amount 
+       ArenaSet<HInstruction*>* set = induction_analysis_->LookupCycle(phi);
+       for (HInstruction* ins : *set) {
+          if (ins->IsAdd()) { 
+            HBinaryOperation* op = ins->AsAdd();
+            HConstant* cst = op->GetConstantRight();
+            if (cst != nullptr) {
+               biv_increment_=op;
+              return true;
+            }
+        }
+      }
+      }
+    }
+  }
+  return false;
+}
+
+void InductionVarSimplification::PerformReduction(HLoopInformation* loop, HInstruction* derived_var,
+                  std::tuple<HInstruction*, HConstant*, HConstant*> val) {
+    DCHECK(biv_increment_ != nullptr);
+    HInstruction* var = std::get<0>(val);
+    HPhi* phi = var->AsPhi();
+    DCHECK(phi != nullptr);
+    HInstruction* input = GetOutOfLoopInput(loop, phi);
+    // Create two new instructions mul and add
+    ArenaAllocator* allocator = derived_var->GetBlock()->GetGraph()->GetAllocator();
+    HInstruction* new_mul =  new (allocator) HMul(derived_var->GetType(), input, std::get<1>(val), derived_var->GetDexPc());
+    loop->GetPreHeader()->InsertInstructionBefore(new_mul, loop->GetPreHeader()->GetLastInstruction());
+    HInstruction* new_add = new (allocator) HAdd(new_mul->GetType(), new_mul,std::get<2>(val), derived_var->GetDexPc());
+    loop->GetPreHeader()->InsertInstructionBefore(new_add, loop->GetPreHeader()->GetLastInstruction());
+    HPhi* new_phi = new (allocator) HPhi(allocator, kNoRegNumber, 0, phi->GetType());
+    phi->GetBlock()->InsertPhiAfter(new_phi, phi);
+    new_phi->AddInput(new_add);
+    HConstant* biv_inc_cst = biv_increment_->GetConstantRight();
+    HConstant* biv_cst = GetNewConstant(HInstruction::InstructionKind::kMul, biv_inc_cst, std::get<1>(val));
+    DCHECK(biv_cst != nullptr);
+    HAdd* biv_add = new (allocator) HAdd(biv_inc_cst->GetType(), new_phi, biv_cst);
+    biv_increment_->GetBlock()->InsertInstructionAfter(biv_add, biv_increment_);
+    new_phi->AddInput(biv_add);
+    // Replace uses of new add within the loop with new_phi
+    const HUseList<HInstruction*>& uses = derived_var->GetUses();
+    for (auto it = uses.begin(), end = uses.end(); it != end;) {
+      HInstruction* user = it->GetUser();
+      size_t input_index = it->GetIndex();
+      ++it;
+      user->ReplaceInput(new_phi, input_index);
+    }
+    const HUseList<HEnvironment*>& env_uses = derived_var->GetEnvUses();
+    for (auto it = env_uses.begin(), end = env_uses.end(); it != end;) {
+      HEnvironment* user = it->GetUser();
+      size_t index = it->GetIndex();
+      ++it;  // increment prior to potential removal
+      user->RemoveAsUserOfInput(index);
+      user->SetRawEnvAt(index, new_phi);
+      new_phi->AddEnvUseAt(user, index);
+    } 
+    DCHECK(!derived_var->HasUses());
+}
+
+bool InductionVarSimplification::IsCandidateForReduction (
+       HLoopInformation* loop, HPhi* biv, HBinaryOperation* to_check,
+       std::map<HBinaryOperation*, triple>* candidate) {
+
+  HInductionVarAnalysis::InductionInfo* ind_info = induction_analysis_->LookupInfo(loop, to_check);
+  HInductionVarAnalysis::InductionInfo* biv_ind_info = induction_analysis_->LookupInfo(loop, biv);
+  if (ind_info == nullptr)
+    return false;
+  // TODO: Handle Add and Shl is pending
+  DataType::Type type = to_check->GetType();
+  HGraph* graph = to_check->GetBlock()->GetGraph();
+  if (to_check->IsMul()) {
+    HConstant* cst = to_check->GetConstantRight();
+    if (cst == nullptr)
+      return false;
+    HInstruction* left_ins = to_check->InputAt(0);
+    HInstruction* right_ins = to_check->InputAt(1);
+    HInductionVarAnalysis::InductionInfo* left_ins_info = induction_analysis_->LookupInfo(loop, left_ins);
+    HInductionVarAnalysis::InductionInfo* right_ins_info = induction_analysis_->LookupInfo(loop, right_ins);
+    if (HInductionVarAnalysis::InductionEqual(biv_ind_info, left_ins_info)){
+      if (right_ins_info->induction_class == HInductionVarAnalysis::kInvariant) {
+        HConstant * zero = GetConstant(graph, type, 0);
+        candidate->insert(std::pair<HBinaryOperation*, triple>(to_check, std::make_tuple(biv, cst, zero)));
+        return true;
+      }
+    }
+    if (HInductionVarAnalysis::InductionEqual(biv_ind_info, right_ins_info) &&
+        left_ins_info->induction_class == HInductionVarAnalysis::kInvariant) {
+      HConstant* zero = GetConstant(graph, type, 0);
+      candidate->insert(std::pair<HBinaryOperation*, triple>(to_check, std::make_tuple(biv, cst, zero)));
+      return true;
+    }
+  } else if (to_check ->IsAdd() || to_check->IsSub()) {
+    HInstruction* left = to_check->InputAt(0);
+    HInstruction* right = to_check->InputAt(1);
+    HConstant* cst = to_check->GetConstantRight();
+    if (cst == nullptr)
+     return false;
+    if (to_check->IsSub()) {
+     cst = GetNegativeConstant(graph, type, cst);
+    }
+    HInductionVarAnalysis::InductionInfo* left_ins_info = induction_analysis_->LookupInfo(loop,left);
+    HInductionVarAnalysis::InductionInfo* right_ins_info = induction_analysis_->LookupInfo(loop, right);
+    // check for a derived  induction variable
+    if (!HInductionVarAnalysis::InductionEqual(left_ins_info, biv_ind_info) &&
+        !HInductionVarAnalysis::InductionEqual(right_ins_info, biv_ind_info)) {
+      bool found = false;
+      for (auto it : *candidate) {
+        HInductionVarAnalysis::InductionInfo* info = induction_analysis_->LookupInfo(loop, it.first);
+        if (HInductionVarAnalysis::InductionEqual(left_ins_info, info) &&
+            right_ins_info->induction_class == HInductionVarAnalysis::kInvariant) {
+          HConstant * one = GetConstant(graph, type, 1);
+          candidate->insert(std::pair<HBinaryOperation*, triple>(to_check, std::make_tuple( it.first,one, cst)));
+          found = true;
+          break;
+        } else if (HInductionVarAnalysis::InductionEqual(right_ins_info, info)
+                   && left_ins_info->induction_class == HInductionVarAnalysis::kInvariant) {
+          HConstant* one = GetConstant(graph, type, 1);
+          candidate->insert(std::pair<HBinaryOperation*, triple>(to_check, std::make_tuple(it.first, one, cst)));
+          found = true;
+          break;
+        }
+      }
+      if (found == true)
+        return true;
+    }
+  }
+  return false;
+}
+
+bool InductionVarSimplification::SimplifyLoop(HLoopInformation* loop) {
+  bool did_reduction = false;
+  HBasicBlock* header = loop->GetHeader();
+  /*HGraph* gr = header->GetGraph();
+  std::string cur_name = gr->GetDexFile().PrettyMethod(gr->GetMethodIdx());
+  std::cout << "method="<< cur_name <<std::endl;*/
+  std::map<HBinaryOperation*, std::tuple< HInstruction*,HConstant*, HConstant*>> candidate;
+  for (HInstructionIterator it(header->GetPhis()); !it.Done(); it.Advance()) {
+    HInstruction* cur = it.Current();
+    HPhi* phi = cur->AsPhi();
+    if (IsCandidatePhi(loop, phi)) {
+      for (HBlocksInLoopIterator it1(*loop); !it1.Done(); it1.Advance()) {
+        HBasicBlock* block = it1.Current();
+        for (HInstructionIterator it2(block->GetInstructions()); !it2.Done(); it2.Advance()) {
+          HInstruction* to_check = it2.Current();
+          if (to_check->IsBinaryOperation())
+           IsCandidateForReduction(loop, phi, to_check->AsBinaryOperation(), &candidate);
+        }
+      }
+    for (auto itr = candidate.cbegin(); itr != candidate.cend(); itr++) {
+      HBinaryOperation* derived_var = itr->first;
+      HInstruction::InstructionKind kind = derived_var->GetKind();
+      triple val = itr->second;
+      HInstruction* var = std::get<0>(val);
+      if (var->GetId() != phi->GetId()) {
+        HBinaryOperation* var_bin = var->AsBinaryOperation();
+       if (derived_var->IsAdd() || derived_var->IsSub()) {
+         DCHECK(var->IsBinaryOperation());
+         HConstant* new_cst = GetNewConstant(kind, std::get<2>(val), std::get<2>(candidate[var_bin]));
+         DCHECK(new_cst != nullptr);
+         std::get<0>(val) = std::get<0>(candidate[var_bin]);
+         std::get<1>(val) = std::get<1>(candidate[var_bin]);
+         std::get<2>(val) = new_cst;
+         candidate[derived_var] = val;
+       } else if(derived_var->IsMul()) {
+         HConstant* new_cst1 = GetNewConstant(kind, std::get<2>(val), std::get<1>(candidate[var_bin]));
+         HConstant* new_cst2 = GetNewConstant(kind, std::get<2>(val), std::get<2>(candidate[var_bin]));
+         DCHECK(new_cst1 != nullptr);
+         DCHECK(new_cst2 != nullptr);
+         std::get<0>(val) = std::get<0>(candidate[var_bin]);
+         std::get<1>(val) = new_cst1;
+         std::get<2>(val) = new_cst2;
+         candidate[derived_var] = val;
+        }
+    }
+  }
+  // Perform strength Reduction
+  for (auto cur1 = candidate.begin(); cur1 != candidate.end(); cur1++ ) {
+    PerformReduction(loop, cur1->first, cur1->second);
+  }
+  
+ }
+ // clear the candidate map now
+ if (!did_reduction && !candidate.empty()) {
+ did_reduction = true;
+ candidate.clear();
+ }
+}
+  return did_reduction;
+}
+
+} // namespace art

--- a/compiler/optimizing/iv_simplifier.h
+++ b/compiler/optimizing/iv_simplifier.h
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2018 Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+    * this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+    * this list of conditions and the following disclaimer in the documentation
+    * and/or other materials provided with the distribution.
+
+    * Neither the name of Intel Corporation nor the names of its contributors
+    * may be used to endorse or promote products derived from this software
+    * without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef ART_COMPILER_OPTIMIZING_INDUCTION_VAR_SIMPLIFICATION_H_
+#define ART_COMPILER_OPTIMIZING_INDUCTION_VAR_SIMPLIFICATION_H_
+
+#include "nodes.h"
+#include "induction_var_analysis.h"
+#include <tuple>
+
+namespace art {
+
+class InductionVarSimplification {
+ public:
+  explicit  InductionVarSimplification(HInductionVarAnalysis* analysis);
+  
+  /**
+   * @brief Performs Simplification on the loop
+   * @param loop The input loop in the graph.
+   */
+  bool SimplifyLoop(HLoopInformation* loop);
+  /**
+   * @brief Checks if the phi is a basic induction variable
+   *        the loop
+   * @param loop The loop to be checked.
+   * @param phi The phi to be checked.
+   */
+  bool IsCandidatePhi(HLoopInformation* loop, HPhi* phi);
+ private:
+  /**
+   * @brief Performs Strength Reduction to eliminate multplication and
+   *        replace with equivalent addition
+   * @param loop The loop to be simplified.
+   * @param derived_var The derived induction variable upon which
+   *        simplification is applied
+   * @param candidate The mapping of derived induction variables.
+   */
+  void PerformReduction(HLoopInformation* loop, HInstruction* derived_var,   
+                  std::tuple<HInstruction*, HConstant*, HConstant*> val);
+   /**
+   * @brief Checks if an instruction is suitable candidate to perform
+   *         strength reducion 
+   * @param loop The loop to be simplified.
+   * @param to_check The instruction in the loop to be checked
+   * @param candidate A mapping from biv to corresponding 
+   *        derived induction variables
+   *        Stores an induction of the form j = a*i +b where i is biv,
+   *        as an entry [j, <i, a, b>]
+   */
+  bool IsCandidateForReduction(HLoopInformation* loop, HPhi* biv, HBinaryOperation* to_check,
+                                std::map<HBinaryOperation*, std::tuple<HInstruction*,HConstant*, HConstant*>>* candidate);
+
+  HInductionVarAnalysis* induction_analysis_;
+  HBinaryOperation* biv_increment_;
+  /* Results of induction var analysis */
+  friend class HInductionVarAnalysis;
+
+  DISALLOW_COPY_AND_ASSIGN(InductionVarSimplification);
+};
+
+}  // namespace art
+
+#endif  // ART_COMPILER_OPTIMIZING_INDUCTION_VAR_SIMPLIFICATION_H_

--- a/compiler/optimizing/loop_optimization.cc
+++ b/compiler/optimizing/loop_optimization.cc
@@ -27,6 +27,7 @@
 #include "linear_order.h"
 #include "mirror/array-inl.h"
 #include "mirror/string.h"
+#include <iostream>
 
 namespace art {
 
@@ -413,6 +414,7 @@ HLoopOptimization::HLoopOptimization(HGraph* graph,
     : HOptimization(graph, name, stats),
       compiler_driver_(compiler_driver),
       induction_range_(induction_analysis),
+      induction_var_sim_(induction_analysis),
       loop_allocator_(nullptr),
       global_allocator_(graph_->GetAllocator()),
       top_loop_(nullptr),
@@ -716,7 +718,15 @@ bool HLoopOptimization::TryOptimizeInnerLoopFinite(LoopNode* node) {
 
 bool HLoopOptimization::OptimizeInnerLoop(LoopNode* node) {
   return (TryOptimizeInnerLoopFinite(node) ||
-          TryFullUnrolling(node));
+          TryFullUnrolling(node) || TryInductionVarSimplification(node));
+
+}
+
+bool HLoopOptimization::TryInductionVarSimplification(LoopNode* node) {
+  HLoopInformation* loop_info = node->loop_info;
+  if (!induction_var_sim_.SimplifyLoop(loop_info))
+    return false;
+ return true;
 
 }
 

--- a/compiler/optimizing/loop_optimization.h
+++ b/compiler/optimizing/loop_optimization.h
@@ -20,6 +20,7 @@
 #include "base/scoped_arena_allocator.h"
 #include "base/scoped_arena_containers.h"
 #include "induction_var_range.h"
+#include "iv_simplifier.h"
 #include "loop_analysis.h"
 #include "nodes.h"
 #include "optimization.h"
@@ -143,6 +144,8 @@ class HLoopOptimization : public HOptimization {
   bool TryOptimizeInnerLoopFinite(LoopNode* node);
   
   bool TryFullUnrolling(LoopNode* node);
+  
+  bool TryInductionVarSimplification(LoopNode* node);
 
   //
   // Vectorization analysis and synthesis.
@@ -238,6 +241,9 @@ class HLoopOptimization : public HOptimization {
 
   // Range information based on prior induction variable analysis.
   InductionVarRange induction_range_;
+
+  // Perform Induction Var Simplification
+  InductionVarSimplification induction_var_sim_;
 
   // Phase-local heap memory allocator for the loop optimizer. Storage obtained
   // through this allocator is immediately released when the loop optimizer is done.

--- a/test/000-checker-ind-var-ele/info.txt
+++ b/test/000-checker-ind-var-ele/info.txt
@@ -1,0 +1,1 @@
+Test for Strength Reduction in Induction Variables 

--- a/test/000-checker-ind-var-ele/src/Main.java
+++ b/test/000-checker-ind-var-ele/src/Main.java
@@ -1,0 +1,251 @@
+import java.util.*;
+
+public class Main{
+
+  static int n = 10;
+
+  public static void assertIntEquals(int expected, int result) {
+    if (expected != result) {
+      throw new Error("Expected: " + expected + ", found: " + result);
+    }
+  }
+
+  public static void assertFloatEquals(float expected, float result) {
+    if (Float.compare(expected,result)!=0) {
+      throw new Error("Expected: " + expected + ", found: " + result);
+    }
+  }
+  public static void assertDoubleEquals(double expected, double result) {
+    if (Double.compare(expected,result)!=0) {
+      throw new Error("Expected: " + expected + ", found: " + result);
+    }
+  }
+
+/// CHECK-START: void Main.Test1() loop_optimization (before)
+/// CHECK-DAG: <<Inc:i\d+>> IntConstant 2 loop:none
+/// CHECK-DAG: <<Phi:i\d+>> Phi loop:<<Loop:B\d+>>
+/// CHECK-DAG: Mul loop:<<Loop>>
+/// CHECK-DAG: Add loop:<<Loop>>
+/// CHECK-DAG: Add loop:<<Loop>>
+/// CHECK-DAG: Add [<<Phi>>,<<Inc>>] loop:<<Loop>>
+
+//
+/// CHECK-START: void Main.Test1() loop_optimization (after)
+/// CHECK-DAG: <<Inc1:i\d+>> IntConstant 2 loop:none
+/// CHECK-DAG: <<Inc2:i\d+>> IntConstant 12 loop:none
+/// CHECK-DAG:               Mul          loop:none
+/// CHECK-DAG:               Add          loop:none
+/// CHECK-DAG:               Mul          loop:none
+/// CHECK-DAG:               Add          loop:none
+/// CHECK-DAG: <<Biv:i\d+>>  Phi        loop:<<Loop:B\d+>>
+/// CHECK-DAG: <<Phi1:i\d+>> Phi        loop:<<Loop>>
+/// CHECK-DAG: <<Phi2:i\d+>> Phi        loop:<<Loop>>
+/// CHECK-DAG:               Mul        loop:<<Loop>>
+/// CHECK-DAG:               Add        loop:<<Loop>>
+/// CHECK-DAG:               Add        loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Biv>>,<<Inc1>>]      loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi1>>,<<Inc2>>]      loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi2>>,<<Inc2>>]      loop:<<Loop>>
+
+/// CHECK-START: void Main.Test1() dead_code_elimination$final (after)
+/// CHECK-NOT:               Mul         loop:<<B\d+>>
+/// CHECK-NOT:               Mul         loop:none
+public static void Test1() {
+  int arr[] = new int[50];
+  int k =0; int j=0;
+  while (k<n) {
+    j = 6*k+1;
+   arr[j] = arr[j]-2;
+   k = k+2;
+  }
+}
+
+/// CHECK-START: int Main.Test2() loop_optimization (before)
+/// CHECK-DAG: <<Inc:i\d+>> IntConstant 1 loop:none
+/// CHECK-DAG: <<Phi1:i\d+>> Phi loop:<<Loop:B5>>
+/// CHECK-DAG: <<Phi2:i\d+>> Phi loop:<<Loop>>
+/// CHECK-DAG: Mul loop:<<Loop>>
+/// CHECK-DAG: Add loop:<<Loop>>
+/// CHECK-DAG: Add loop:<<Loop>>
+/// CHECK-DAG: Add loop:<<Loop>>
+/// CHECK-DAG: Add [<<Phi1>>,<<Inc>>] loop:<<Loop>>
+
+//
+/// CHECK-START: int Main.Test2() loop_optimization (after)
+/// CHECK-DAG: <<Inc1:i\d+>> IntConstant 1 loop:none
+/// CHECK-DAG: <<Inc2:i\d+>> IntConstant 11 loop:none
+/// CHECK-DAG:               Mul            loop:none
+/// CHECK-DAG:               Add            loop:none
+/// CHECK-DAG:               Mul            loop:none
+/// CHECK-DAG:               Add            loop:none
+/// CHECK-DAG: <<Phi1:i\d+>> Phi        loop:<<Loop:B5>>
+/// CHECK-DAG: <<Phi2:i\d+>> Phi        loop:<<Loop>>
+/// CHECK-DAG: <<Phi3:i\d+>> Phi        loop:<<Loop>>
+/// CHECK-DAG: <<Phi4:i\d+>> Phi        loop:<<Loop>>
+/// CHECK-DAG:               Mul        loop:<<Loop>>
+/// CHECK-DAG:               Add        loop:<<Loop>>
+/// CHECK-DAG:               Add        loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi1>>,<<Inc1>>]      loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi2>>,<<Inc2>>]      loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi3>>,<<Inc2>>]      loop:<<Loop>>
+
+/// CHECK-START: int Main.Test2() dead_code_elimination$final (after)
+/// CHECK-NOT:               Mul            loop:none
+/// CHECK-NOT:               Mul         loop:<<B\d+>>
+public static int Test2() {
+ int n = 36;
+ float [] radius = new float [n];
+Random r = new Random();
+for (int i = 0; i< n ; i++) {
+  radius[i] = r.nextFloat();
+}
+int sum = 0;
+for (int ii= 0 ; ii< n; ii++){
+  int k = 11*ii;
+  int m = k + 5;
+  sum += radius[ii] + m;
+}
+ return sum;
+}
+
+/// CHECK-START: int Main.Test3() loop_optimization (before)
+/// CHECK-DAG: <<Inc:i\d+>> IntConstant 1 loop:none
+/// CHECK-DAG: <<Phi1:i\d+>> Phi          loop:<<Loop:B\d+>>
+/// CHECK-DAG: <<Phi2:i\d+>> Phi          loop:<<Loop>>
+/// CHECK-DAG: Shl                        loop:<<Loop>>
+/// CHECK-DAG: Mul                        loop:<<Loop>>
+/// CHECK-DAG: Add [<<Phi1>>,<<Inc>>]     loop:<<Loop>>
+
+//
+/// CHECK-START: int Main.Test3() loop_optimization (after)
+/// CHECK-DAG: <<Inc1:i\d+>> IntConstant 1           loop:none
+/// CHECK-DAG: <<Inc2:i\d+>> IntConstant 6           loop:none
+/// CHECK-DAG:               Mul                     loop:none
+/// CHECK-DAG:               Add                     loop:none
+/// CHECK-DAG: <<Phi1:i\d+>> Phi                     loop:<<Loop:B\d+>>
+/// CHECK-DAG: <<Phi2:i\d+>> Phi                     loop:<<Loop>>
+/// CHECK-DAG: <<Phi3:i\d+>> Phi                     loop:<<Loop>>
+/// CHECK-DAG:               Shl                     loop:<<Loop>>
+/// CHECK-DAG:               Mul                     loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi1>>,<<Inc1>>] loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi2>>,<<Inc2>>] loop:<<Loop>>
+
+/// CHECK-START: int Main.Test3() dead_code_elimination$final (after)
+/// CHECK-NOT: Mul loop:<<B\d+>>
+public static int Test3() {
+ int k =0;
+ for (int i= 0; i< n; i++){
+   if (i%2 == 0) {
+     k = (int) 6.14*i;
+   }
+   else {
+    k = (int)2.69* i;
+   }
+ }
+return k;
+}
+
+/// CHECK-START: float Main.Test4() loop_optimization (before)
+/// CHECK-DAG: <<Inc:f\d+>> FloatConstant 1 loop:none
+/// CHECK-DAG: <<Phi1:f\d+>> Phi          loop:<<Loop:B\d+>>
+/// CHECK-DAG: <<Phi2:f\d+>> Phi          loop:<<Loop>>
+/// CHECK-DAG: Mul                        loop:<<Loop>>
+/// CHECK-DAG: Add                        loop:<<Loop>>
+/// CHECK-DAG: Add                        loop:<<Loop>>
+/// CHECK-DAG: Add [<<Phi1>>,<<Inc>>]     loop:<<Loop>>
+
+/// CHECK-START: float Main.Test4() loop_optimization (after)
+/// CHECK-DAG: <<Inc1:f\d+>> FloatConstant 11.11     loop:none
+/// CHECK-DAG: <<Inc2:f\d+>> FloatConstant 2.69      loop:none
+/// CHECK-DAG: <<Inc3:f\d+>> FloatConstant 1         loop:none
+/// CHECK-DAG:               Mul                     loop:none
+/// CHECK-DAG:               Add                     loop:none
+/// CHECK-DAG:               Mul                     loop:none
+/// CHECK-DAG:               Add                     loop:none
+/// CHECK-DAG: <<Phi1:f\d+>> Phi                     loop:<<Loop:B\d+>>
+/// CHECK-DAG: <<Phi2:f\d+>> Phi                     loop:<<Loop>>
+/// CHECK-DAG: <<Phi3:f\d+>> Phi                     loop:<<Loop>>
+/// CHECK-DAG: <<Phi4:f\d+>> Phi                     loop:<<Loop>>
+/// CHECK-DAG: <<Phi5:i\d+>> Phi                     loop:<<Loop>>
+/// CHECK-DAG:               Mul                     loop:<<Loop>>
+/// CHECK-DAG:               Add                     loop:<<Loop>>
+/// CHECK-DAG:               Add                     loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi1>>,<<Inc3>>] loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi2>>,<<Inc1>>] loop:<<Loop>>
+/// CHECK-DAG:               Add [<<Phi3>>,<<Inc1>>] loop:<<Loop>>
+
+/// CHECK-START: float Main.Test4() dead_code_elimination$final (after)
+/// CHECK-NOT: Mul loop:<<B\d+>>
+
+public static float Test4(){
+  float k = 0.0f;
+  int times = 0;
+  for (float f = 0.0f ; f <= 10.0f; f += 1.0f) {
+    k = 11.11f * f + 2.69f;
+    times++;
+   }
+   return k*times;
+ }
+
+public static void TestSub1() {
+  int arr[] = new int[50];
+  int k =0; int j=0;
+  while (k<n) {
+    j = 6*k-1;
+   arr[j] = arr[j]-2;
+   k = k+2;
+  }
+}
+
+/// CHECK-START: double Main.Test5() loop_optimization (before)
+/// CHECK-DAG: <<Var1:d\d+>> DoubleConstant 0 loop:none
+/// CHECK-DAG: <<Var2:d\d+>> DoubleConstant 1 loop:none
+/// CHECK-DAG: <<Phi1:d\d+>> Phi [<<Var1>>,<<Add:d\d+>>]     loop:<<Loop:B\d+>>
+/// CHECK-DAG: <<Phi2:d\d+>> Phi [<<Var1>>,<<Sub:d\d+>>]     loop:<<Loop>>
+/// CHECK-DAG:               Mul                        loop:<<Loop>>
+/// CHECK-DAG:               Mul                        loop:<<Loop>>
+/// CHECK-DAG: <<Sub>>       Sub                        loop:<<Loop>>
+/// CHECK-DAG: <<Add>>       Add [<<Phi1>>,<<Var2>>]    loop:<<Loop>>
+
+/// CHECK-START: double Main.Test5() loop_optimization (after)
+/// CHECK-DAG: <<Var1:d\d+>>    DoubleConstant 0           loop:none
+/// CHECK-DAG: <<Var2:d\d+>>    DoubleConstant 1           loop:none
+/// CHECK-DAG: <<Var3:d\d+>>    DoubleConstant 3.14        loop:none
+/// CHECK-DAG:                  Mul                        loop:none
+/// CHECK-DAG: <<Add2:d\d+>>    Add                        loop:none
+/// CHECK-DAG: <<Phi1:d\d+>>    Phi [<<Var1>>,<<Add:d\d+>>]     loop:<<Loop:B\d+>>
+/// CHECK-DAG: <<NewPhi:d\d+>>  Phi [<<Add2>>,<<NewAdd:d\d+>>]  loop:<<Loop>>
+/// CHECK-DAG: <<Phi2:d\d+>>    Phi [<<Var1>>,<<Sub:d\d+>>]    loop:<<Loop>>
+/// CHECK-DAG:                  Mul                        loop:<<Loop>>
+/// CHECK-DAG:                  Mul                        loop:<<Loop>>
+/// CHECK-DAG: <<Sub>>          Sub                        loop:<<Loop>>
+/// CHECK-DAG: <<Add>>          Add [<<Phi1>>,<<Var2>>]    loop:<<Loop>>
+/// CHECK-DAG: <<NewAdd>>      Add [<<NewPhi>>,<<Var3>>] loop:<<Loop>>
+
+/// CHECK-START: double Main.Test5() dead_code_elimination$final (after)
+/// CHECK:  Mul loop:<<Loop:B\d+>>
+/// CHECK-NEXT: Sub loop:<<Loop>>
+
+public static double Test5(){
+  double volume = 0.0d;
+  double pi = 3.14;
+  double c = 4/3;
+  int times = 0;
+  for (double r = 0.0d ; r <= 10.0d; r += 1.0d) {
+    volume = pi*c*r*r;
+    volume -= 100d;
+   }
+   return volume;
+ }
+
+public static void main(String[] args) {
+
+  Test1();
+  assertIntEquals(7110, Test2());
+  assertFloatEquals (18.0f, Test3());
+  assertFloatEquals(1251.6901f,Test4());
+  assertDoubleEquals(214.0,Test5());
+}
+
+
+}


### PR DESCRIPTION
Basic idea:

replace expensive operations (multiplications) with cheaper ones
(additions) in definitions of induction variables

while (i<10) {
j = a*i+b;
a[j] = a[j]-2;
i = i+c;
}

with

s = a*i+b;
  while (i < 10){
   j = s;
 a[j] = a[j]-2;
i = i+c;
s= s+a*c;
}
Idea of the optimization taken from below link:
https://www.cs.cmu.edu/afs/cs/academic/class/15745-s16/www/lectures/L10-Strength-Reduction.pdf

Tracked-On: OAM-75637
Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>