### PR TITLE
During Concurrent copying (CC) collection when native code is accessi…

### DIFF
--- a/runtime/gc/heap.h
+++ b/runtime/gc/heap.h
@@ -540,6 +540,9 @@ class Heap {
     return total_bytes_freed_ever_;
   }
 
+   space::RegionSpace* GetRegionSpace() const {
+    return region_space_;
+  }
   // Implements java.lang.Runtime.maxMemory, returning the maximum amount of memory a program can
   // consume. For a regular VM this would relate to the -Xmx option and would return -1 if no Xmx
   // were specified. Android apps start with a growth limit (small heap size) which is
@@ -872,6 +875,13 @@ class Heap {
   void RemoveGcPauseListener();
 
   const Verification* GetVerification() const;
+
+
+  // Return the status of threadflip running or not
+  bool is_thread_flip_running(Thread* self) REQUIRES(!*thread_flip_lock_){
+       MutexLock mu(self, *thread_flip_lock_);
+       return thread_flip_running_;
+  }
 
  private:
   class ConcurrentGCTask;

--- a/runtime/gc/space/region_space.h
+++ b/runtime/gc/space/region_space.h
@@ -99,6 +99,10 @@ class RegionSpace FINAL : public ContinuousMemMapAllocSpace {
     return mark_bitmap_.get();
   }
 
+  //Set the Region type  as Native
+  void IncCountForRegionRefByNative(mirror::Object* ref) REQUIRES(!region_lock_);
+  void DecCountForRegionRefByNative(mirror::Object* ref) REQUIRES(!region_lock_);
+
   void Clear() OVERRIDE REQUIRES(!region_lock_);
 
   // Change the non growth limit capacity to new capacity by shrinking or expanding the map.
@@ -295,7 +299,7 @@ class RegionSpace FINAL : public ContinuousMemMapAllocSpace {
           begin_(nullptr), top_(nullptr), end_(nullptr),
           state_(RegionState::kRegionStateAllocated), type_(RegionType::kRegionTypeToSpace),
           objects_allocated_(0), alloc_time_(0), live_bytes_(static_cast<size_t>(-1)),
-          is_newly_allocated_(false), is_a_tlab_(false), thread_(nullptr) {}
+          is_newly_allocated_(false), is_ref_by_native_(0), is_a_tlab_(false), thread_(nullptr) {}
 
     void Init(size_t idx, uint8_t* begin, uint8_t* end) {
       idx_ = idx;
@@ -308,6 +312,7 @@ class RegionSpace FINAL : public ContinuousMemMapAllocSpace {
       alloc_time_ = 0;
       live_bytes_ = static_cast<size_t>(-1);
       is_newly_allocated_ = false;
+      is_ref_by_native_=0;
       is_a_tlab_ = false;
       thread_ = nullptr;
       DCHECK_LT(begin, end);
@@ -503,6 +508,7 @@ class RegionSpace FINAL : public ContinuousMemMapAllocSpace {
     // special value for `live_bytes_`.
     size_t live_bytes_;                 // The live bytes. Used to compute the live percent.
     bool is_newly_allocated_;           // True if it's allocated after the last collection.
+    uint32_t is_ref_by_native_;         // True if java array or string is used by native.
     bool is_a_tlab_;                    // True if it's a tlab.
     Thread* thread_;                    // The owning thread if it's a tlab.
 


### PR DESCRIPTION
…ng the Java array or Java string instead of pausing the GC while native code is acccessing the Java memory we will pass the information to the Concurrent copying (CC) collector not to touch those region which is refered by Native code.

Tracked-On: OAM-76424
Signed-off-by: Atul Bajaj <atul.bajaj@intel.com>