### PR TITLE
Enable libart to use ipp optimized static libz.

### DIFF
--- a/dexlayout/Android.bp
+++ b/dexlayout/Android.bp
@@ -29,7 +29,26 @@ art_cc_defaults {
     shared_libs: [
         "libbase",
     ],
-    static_libs: ["libz"],
+    target: {
+      android_x86: {
+            static_libs: [
+                // ZipArchive support, the order matters here to get all symbols.
+                "libziparchive",
+                "libz", //static version of libz as a part of inflate
+            ],
+        },
+     android_x86_64: {
+            static_libs: [
+                // ZipArchive support, the order matters here to get all symbols.
+                "libziparchive",
+                "libz_ipp",
+                "zlib-ipp",
+            ],
+        },
+     host: {
+         static_libs: ["libz"],
+     },
+   },
 }
 
 art_cc_library {

--- a/libdexfile/Android.bp
+++ b/libdexfile/Android.bp
@@ -37,12 +37,23 @@ cc_defaults {
 
     target: {
         android: {
-            static_libs: [
-                "libziparchive",
-                "libz",
-            ],
             shared_libs: [
                 "libutils",
+            ],
+        },
+        android_x86: {
+	    static_libs: [
+                // ZipArchive support, the order matters here to get all symbols.
+                "libziparchive",
+                "libz", //static version of libz as a part of inflate
+            ],
+        },
+        android_x86_64: {
+	    static_libs: [
+                // ZipArchive support, the order matters here to get all symbols.
+                "libziparchive",
+                "libz_ipp",
+                "zlib-ipp",
             ],
         },
         host: {

--- a/runtime/Android.bp
+++ b/runtime/Android.bp
@@ -373,11 +373,7 @@ cc_defaults {
                 "libutils",
                 "libtombstoned_client",
             ],
-            static_libs: [
-                // ZipArchive support, the order matters here to get all symbols.
-                "libziparchive",
-                "libz",
-            ],
+
         },
         android_arm: {
             ldflags: JIT_DEBUG_REGISTER_CODE_LDFLAGS,
@@ -387,9 +383,20 @@ cc_defaults {
         },
         android_x86: {
             ldflags: JIT_DEBUG_REGISTER_CODE_LDFLAGS,
+	    static_libs: [
+                // ZipArchive support, the order matters here to get all symbols.
+                "libziparchive",
+                "libz", //static version of libz as a part of inflate
+            ],
         },
         android_x86_64: {
             ldflags: JIT_DEBUG_REGISTER_CODE_LDFLAGS,
+	    static_libs: [
+                // ZipArchive support, the order matters here to get all symbols.
+                "libziparchive",
+                "libz_ipp",
+                "zlib-ipp",
+            ],
         },
         host: {
             srcs: [


### PR DESCRIPTION
Category: Device Enablement
Origin: Internal
Upstream-Candidate: no
Tracked-On: https://jira.devtools.intel.com/browse/OAM-79155
Signed-off-by: Priyanka Bose <priyanka.bose@intel.com>