### PR TITLE
Fixing Klocwork issues on binary analyzer

### DIFF
--- a/runtime/binary_analyzer/binary_analyzer_x86.h
+++ b/runtime/binary_analyzer/binary_analyzer_x86.h
@@ -137,8 +137,8 @@ class MachineInstruction {
   std::string instr_;
   const uint8_t* instr_ptr_;
   uint8_t length_;
-  MachineInstruction* prev_instr_;
-  MachineInstruction* next_instr_;
+  MachineInstruction* prev_instr_ = nullptr;
+  MachineInstruction* next_instr_ = nullptr;
 };
 
 /**
@@ -685,7 +685,7 @@ class CFGraph {
   }
 
  private:
-  MachineBlock* start_bblock_;
+  MachineBlock* start_bblock_ = nullptr;
   uint32_t num_of_bblocks_ = 0u;
   uint32_t num_of_instrs_ = 0u;
   uint32_t call_depth_ = 0u;

--- a/runtime/binary_analyzer/disassembler.cc
+++ b/runtime/binary_analyzer/disassembler.cc
@@ -29,6 +29,7 @@ Disassembler::Disassembler(InstructionSet insn_set) {
   ptr_ = nullptr;
   address_ = 0;
   insn_ = nullptr;
+  handle_ = 0;
   // Instantiate a capstone handle/instance.
   switch (insn_set) {
   case InstructionSet::kX86:

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -1112,7 +1112,7 @@ class Runtime {
   std::unique_ptr<MemMap> protected_fault_page_;
 #ifdef CAPSTONE
   // Auto Fast JNI detection gate.
-  bool auto_fast_detect_;
+  bool auto_fast_detect_ = true;
 #endif
 
 


### PR DESCRIPTION
Category: device enablement
Domain: AOSP.ART-Other
Origin: internal
Upstream-Candidate: no, proprietary
Tracked-On: https://jira.devtools.intel.com/browse/OAM-81108
Signed-off-by: Priyanka Bose <priyanka.bose@intel.com>