### PR TITLE
Revert mfence patch in KBL_NUC P desert

### DIFF
--- a/libartbase/base/atomic.h
+++ b/libartbase/base/atomic.h
@@ -28,14 +28,6 @@
 
 namespace art {
 
-static inline void ThreadFenceAsmX86() {
-#if defined(__i386__)
-  __asm__ __volatile__("lock; addl $0,0(%%esp)" : : : "cc", "memory");
-#elif defined(__x86_64__)
-  __asm__ __volatile__("lock; addl $0,0(%%rsp)" : : : "cc", "memory");
-#endif
-}
-
 template<typename T>
 class PACKED(sizeof(T)) Atomic : public std::atomic<T> {
  public:
@@ -84,12 +76,7 @@ class PACKED(sizeof(T)) Atomic : public std::atomic<T> {
 
   // Store to memory with a total ordering.
   void StoreSequentiallyConsistent(T desired_value) {
-    #if defined(__i386__) || defined(__x86_64__)
-       this->store(desired_value, std::memory_order_seq_cst);
-       ThreadFenceAsmX86();
-    #else
-       this->store(desired_value, std::memory_order_seq_cst);
-    #endif
+    this->store(desired_value, std::memory_order_seq_cst);
   }
 
   // Atomically replace the value with desired_value.

--- a/runtime/base/quasi_atomic.h
+++ b/runtime/base/quasi_atomic.h
@@ -26,7 +26,6 @@
 
 #include "arch/instruction_set.h"
 #include "base/macros.h"
-#include "base/atomic.h"
 
 namespace art {
 
@@ -170,11 +169,7 @@ class QuasiAtomic {
   }
 
   static void ThreadFenceSequentiallyConsistent() {
-    #if defined(__i386__) || defined(__x86_64__)
-      ThreadFenceAsmX86();
-    #else
-      std::atomic_thread_fence(std::memory_order_seq_cst);
-    #endif
+    std::atomic_thread_fence(std::memory_order_seq_cst);
   }
 
  private:


### PR DESCRIPTION
Tracked-On: https://jira.devtools.intel.com/browse/OAM-83088
Signed-off-by: anuvarsh <anuvarshini.bc@intel.com>
Category: device enablement
Domain: AOSP.ART-Other
Origin: internal
Upstream-Candidate: no, proprietary